### PR TITLE
Handles empty traces.

### DIFF
--- a/lib/src/trace.dart
+++ b/lib/src/trace.dart
@@ -263,7 +263,7 @@ class Trace implements StackTrace {
         var library = frame.library.replaceAll(_terseRegExp, '');
         return new Frame(Uri.parse(library), null, null, frame.member);
       }).toList();
-      if (newFrames.first.isCore && newFrames.length > 1) newFrames.removeAt(0);
+      if (newFrames.length > 1 && newFrames.first.isCore) newFrames.removeAt(0);
     }
 
     return new Trace(newFrames.reversed);

--- a/test/trace_test.dart
+++ b/test/trace_test.dart
@@ -350,6 +350,14 @@ dart:core  bottom
 '''));
   });
 
+  test(".terse won't panic on an empty trace", () {
+    var trace = new Trace.parse('''
+''');
+
+    expect(trace.terse.toString(), equals('''
+'''));
+  });
+
   test('.foldFrames folds frames together bottom-up', () {
     var trace = new Trace.parse('''
 #0 notFoo (foo.dart:42:21)


### PR DESCRIPTION
Previously .terse() would die if it processes an empty stack trace.
