### PR TITLE
Fix broken README links.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.7.3
+
+* Fix broken links in the README.
+
 ## 1.7.2
 
 * `Trace.foldFrames()` and `Chain.foldFrames()` now remove the outermost folded

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ the native [StackTrace] implementation.
 using `Trace.current`. Native [StackTrace]s can also be directly converted to
 human-readable strings using `Trace.format`.
 
-[StackTrace]: http://api.dartlang.org/docs/releases/latest/dart_core/StackTrace.html
+[StackTrace]: https://api.dartlang.org/stable/dart-core/StackTrace-class.html
 
 Here's an example native stack trace from debugging this library:
 
@@ -202,4 +202,4 @@ this:
 
 That's a lot easier to understand!
 
-[Zone]: https://api.dartlang.org/apidocs/channels/stable/#dart-async.Zone
+[Zone]: https://api.dartlang.org/stable/dart-async/Zone-class.html

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ name: stack_trace
 #
 # When the major version is upgraded, you *must* update that version constraint
 # in pub to stay in sync with this.
-version: 1.7.2
+version: 1.7.3
 author: "Dart Team <misc@dartlang.org>"
 homepage: https://github.com/dart-lang/stack_trace
 description: >


### PR DESCRIPTION
Closes dart-lang/tools#1829