### PR TITLE
Always run onError callbacks for Chain.capture() in the parent zone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.7.4
+
+* Always run `onError` callbacks for `Chain.capture()` in the parent zone.
+
 ## 1.7.3
 
 * Fix broken links in the README.

--- a/lib/src/stack_zone_specification.dart
+++ b/lib/src/stack_zone_specification.dart
@@ -138,7 +138,7 @@ class StackZoneSpecification {
     // TODO(nweiz): Currently this copies a lot of logic from [runZoned]. Just
     // allow [runBinary] to throw instead once issue 18134 is fixed.
     try {
-      return parent.runBinary(zone, _onError, error, stackChain);
+      return self.parent.runBinary(_onError, error, stackChain);
     } catch (newError, newStackTrace) {
       if (identical(newError, error)) {
         return parent.handleUncaughtError(zone, error, stackChain);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ name: stack_trace
 #
 # When the major version is upgraded, you *must* update that version constraint
 # in pub to stay in sync with this.
-version: 1.7.4-dev
+version: 1.7.4
 author: "Dart Team <misc@dartlang.org>"
 homepage: https://github.com/dart-lang/stack_trace
 description: A package for manipulating stack traces and printing them readably.


### PR DESCRIPTION
Closes dart-lang/tools#1833