### PR TITLE
Zone.strong

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.8.2
+
+* Update to use strong-mode clean Zone API.
+
 ## 1.8.1
 
 * Use official generic function syntax.

--- a/lib/src/chain.dart
+++ b/lib/src/chain.dart
@@ -93,7 +93,8 @@ class Chain implements StackTrace {
         return callback();
       } catch (error, stackTrace) {
         // TODO(nweiz): Don't special-case this when issue 19566 is fixed.
-        return Zone.current.handleUncaughtError(error, stackTrace);
+        Zone.current.handleUncaughtError(error, stackTrace);
+        return null;
       }
     },
         zoneSpecification: spec.toSpec(),

--- a/lib/src/stack_zone_specification.dart
+++ b/lib/src/stack_zone_specification.dart
@@ -102,7 +102,7 @@ class StackZoneSpecification {
   /// Tracks the current stack chain so it can be set to [_currentChain] when
   /// [f] is run.
   ZoneUnaryCallback<R, T> _registerUnaryCallback<R, T>(
-      Zone self, ZoneDelegate parent, Zone zone, R f(T arg) {
+      Zone self, ZoneDelegate parent, Zone zone, R f(T arg)) {
     if (f == null || _disabled) return parent.registerUnaryCallback(zone, f);
     var node = _createNode(1);
     return parent.registerUnaryCallback(zone, (arg) {

--- a/lib/src/stack_zone_specification.dart
+++ b/lib/src/stack_zone_specification.dart
@@ -128,11 +128,13 @@ class StackZoneSpecification {
       Zone self, ZoneDelegate parent, Zone zone, error, StackTrace stackTrace) {
     if (_disabled) {
       parent.handleUncaughtError(zone, error, stackTrace);
+      return;
     }
 
     var stackChain = chainFor(stackTrace);
     if (_onError == null) {
       parent.handleUncaughtError(zone, error, stackChain);
+      return;
     }
 
     // TODO(nweiz): Currently this copies a lot of logic from [runZoned]. Just

--- a/lib/src/stack_zone_specification.dart
+++ b/lib/src/stack_zone_specification.dart
@@ -92,8 +92,8 @@ class StackZoneSpecification {
 
   /// Tracks the current stack chain so it can be set to [_currentChain] when
   /// [f] is run.
-  ZoneCallback _registerCallback(
-      Zone self, ZoneDelegate parent, Zone zone, Function f) {
+  ZoneCallback<R> _registerCallback<R>(
+      Zone self, ZoneDelegate parent, Zone zone, R f()) {
     if (f == null || _disabled) return parent.registerCallback(zone, f);
     var node = _createNode(1);
     return parent.registerCallback(zone, () => _run(f, node));
@@ -101,8 +101,8 @@ class StackZoneSpecification {
 
   /// Tracks the current stack chain so it can be set to [_currentChain] when
   /// [f] is run.
-  ZoneUnaryCallback _registerUnaryCallback(
-      Zone self, ZoneDelegate parent, Zone zone, Function f) {
+  ZoneUnaryCallback<R, T> _registerUnaryCallback<R, T>(
+      Zone self, ZoneDelegate parent, Zone zone, R f(T arg) {
     if (f == null || _disabled) return parent.registerUnaryCallback(zone, f);
     var node = _createNode(1);
     return parent.registerUnaryCallback(zone, (arg) {
@@ -112,7 +112,7 @@ class StackZoneSpecification {
 
   /// Tracks the current stack chain so it can be set to [_currentChain] when
   /// [f] is run.
-  ZoneBinaryCallback _registerBinaryCallback(
+  ZoneBinaryCallback<R, T1, T2> _registerBinaryCallback<R, T1, T2>(
       Zone self, ZoneDelegate parent, Zone zone, Function f) {
     if (f == null || _disabled) return parent.registerBinaryCallback(zone, f);
 
@@ -124,26 +124,26 @@ class StackZoneSpecification {
 
   /// Looks up the chain associated with [stackTrace] and passes it either to
   /// [_onError] or [parent]'s error handler.
-  _handleUncaughtError(
+  void _handleUncaughtError(
       Zone self, ZoneDelegate parent, Zone zone, error, StackTrace stackTrace) {
     if (_disabled) {
-      return parent.handleUncaughtError(zone, error, stackTrace);
+      parent.handleUncaughtError(zone, error, stackTrace);
     }
 
     var stackChain = chainFor(stackTrace);
     if (_onError == null) {
-      return parent.handleUncaughtError(zone, error, stackChain);
+      parent.handleUncaughtError(zone, error, stackChain);
     }
 
     // TODO(nweiz): Currently this copies a lot of logic from [runZoned]. Just
     // allow [runBinary] to throw instead once issue 18134 is fixed.
     try {
-      return parent.runBinary(zone, _onError, error, stackChain);
+      parent.runBinary(zone, _onError, error, stackChain);
     } catch (newError, newStackTrace) {
       if (identical(newError, error)) {
-        return parent.handleUncaughtError(zone, error, stackChain);
+        parent.handleUncaughtError(zone, error, stackChain);
       } else {
-        return parent.handleUncaughtError(zone, newError, newStackTrace);
+        parent.handleUncaughtError(zone, newError, newStackTrace);
       }
     }
   }
@@ -180,7 +180,7 @@ class StackZoneSpecification {
   ///
   /// If [f] throws an error, this associates [node] with that error's stack
   /// trace.
-  _run(Function f, _Node node) {
+  T _run<T>(T f(), _Node node) {
     var previousNode = _currentNode;
     _currentNode = node;
     try {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,4 +17,4 @@ dependencies:
 dev_dependencies:
   test: '^0.12.17'
 environment:
-  sdk: ">=2.0-dev.0.1 <2.0-dev.infinity"
+  sdk: ">=1.23.0 <2.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ name: stack_trace
 #
 # When the major version is upgraded, you *must* update that version constraint
 # in pub to stay in sync with this.
-version: 1.8.2
+version: 1.8.2-dev
 author: "Dart Team <misc@dartlang.org>"
 homepage: https://github.com/dart-lang/stack_trace
 description: A package for manipulating stack traces and printing them readably.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,4 +17,4 @@ dependencies:
 dev_dependencies:
   test: '^0.12.17'
 environment:
-  sdk: ">=1.21.0 <2.0.0"
+  sdk: ">=1.25.0 <2.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,4 +17,4 @@ dependencies:
 dev_dependencies:
   test: '^0.12.17'
 environment:
-  sdk: ">=1.23.0 <2.0.0"
+  sdk: ">=2.0-dev.0.1 <2.0-dev.infinity"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ name: stack_trace
 #
 # When the major version is upgraded, you *must* update that version constraint
 # in pub to stay in sync with this.
-version: 1.8.1
+version: 1.8.2
 author: "Dart Team <misc@dartlang.org>"
 homepage: https://github.com/dart-lang/stack_trace
 description: A package for manipulating stack traces and printing them readably.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ name: stack_trace
 #
 # When the major version is upgraded, you *must* update that version constraint
 # in pub to stay in sync with this.
-version: 1.8.2-dev
+version: 1.8.2
 author: "Dart Team <misc@dartlang.org>"
 homepage: https://github.com/dart-lang/stack_trace
 description: A package for manipulating stack traces and printing them readably.


### PR DESCRIPTION
The `dart:async` zone API is in the process of becoming strong-mode clean.
This patch fixes a breakage introduced by this change.