### PR TITLE
Improve handling of VM stack chains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.8.3
+
+* `Chain.forTrace()` now returns a full stack chain for *all* `StackTrace`s
+  within `Chain.capture()`, even those that haven't been processed by
+  `dart:async` yet.
+
 ## 1.8.2
 
 * Update to use strong-mode clean Zone API.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
   within `Chain.capture()`, even those that haven't been processed by
   `dart:async` yet.
 
+* `Chain.forTrace()` now uses the Dart VM's stack chain information when called
+  synchronously within `Chain.capture()`. This matches the existing behavior
+  outside `Chain.capture()`.
+
 ## 1.8.2
 
 * Update to use strong-mode clean Zone API.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@
   synchronously within `Chain.capture()`. This matches the existing behavior
   outside `Chain.capture()`.
 
+* `Chain.forTrace()` now trims the VM's stack chains for the innermost stack
+  trace within `Chain.capture()` (unless it's called synchronously, as above).
+  This avoids duplicated frames and makes the format of the innermost traces
+  consistent with the other traces in the chain.
+
 ## 1.8.2
 
 * Update to use strong-mode clean Zone API.

--- a/lib/src/chain.dart
+++ b/lib/src/chain.dart
@@ -153,6 +153,7 @@ class Chain implements StackTrace {
   factory Chain.forTrace(StackTrace trace) {
     if (trace is Chain) return trace;
     if (_currentSpec != null) return _currentSpec.chainFor(trace);
+    if (trace is Trace) return new Chain([trace]);
     return new LazyChain(() => new Chain.parse(trace.toString()));
   }
 

--- a/lib/src/stack_zone_specification.dart
+++ b/lib/src/stack_zone_specification.dart
@@ -90,13 +90,20 @@ class StackZoneSpecification {
     trace ??= StackTrace.current;
 
     var previous = _chains[trace] ?? _currentNode;
-    if (previous != null) return new _Node(trace, previous).toChain();
+    if (previous == null) {
+      // If there's no [_currentNode], we're running synchronously beneath
+      // [Chain.capture] and we should fall back to the VM's stack chaining. We
+      // can't use [Chain.from] here because it'll just call [chainFor] again.
+      if (trace is Trace) return new Chain([trace]);
+      return new LazyChain(() => new Chain.parse(trace.toString()));
+    } else {
+      if (trace is! Trace) {
+        var original = trace;
+        trace = new LazyTrace(() => new Trace.parse(_trimVMChain(original)));
+      }
 
-    // If there's no [_currentNode], we're running synchronously beneath
-    // [Chain.capture] and we should fall back to the VM's stack chaining. We
-    // can't use [Chain.from] here because it'll just call [chainFor] again.
-    if (trace is Trace) return new Chain([trace]);
-    return new LazyChain(() => new Chain.parse(trace.toString()));
+      return new _Node(trace, previous).toChain();
+    }
   }
 
   /// Tracks the current stack chain so it can be set to [_currentChain] when
@@ -203,6 +210,29 @@ class StackZoneSpecification {
       _currentNode = previousNode;
     }
   }
+
+  /// Like [new Trace.current], but if the current stack trace has VM chaining
+  /// enabled, this only returns the innermost sub-trace.
+  Trace _currentTrace([int level]) {
+    level ??= 0;
+    var stackTrace = StackTrace.current;
+    return new LazyTrace(() {
+      var text = _trimVMChain(stackTrace);
+      var trace = new Trace.parse(text);
+      // JS includes a frame for the call to StackTrace.current, but the VM
+      // doesn't, so we skip an extra frame in a JS context.
+      return new Trace(trace.frames.skip(level + (inJS ? 2 : 1)),
+          original: text);
+    });
+  }
+
+  /// Removes the VM's stack chains from the native [trace], since we're
+  /// generating our own and we don't want duplicate frames.
+  String _trimVMChain(StackTrace trace) {
+    var text = trace.toString();
+    var index = text.indexOf(vmChainGap);
+    return index == -1 ? text : text.substring(0, index);
+  }
 }
 
 /// A linked list node representing a single entry in a stack chain.
@@ -213,8 +243,7 @@ class _Node {
   /// The previous node in the chain.
   final _Node previous;
 
-  _Node(StackTrace trace, [this.previous])
-      : trace = trace == null ? _currentTrace() : new Trace.from(trace);
+  _Node(StackTrace trace, [this.previous]) : trace = new Trace.from(trace);
 
   /// Converts this to a [Chain].
   Chain toChain() {
@@ -226,23 +255,4 @@ class _Node {
     }
     return new Chain(nodes);
   }
-}
-
-/// Like [new Trace.current], but if the current stack trace has VM chaining
-/// enabled, this only returns the innermost sub-trace.
-Trace _currentTrace([int level]) {
-  level ??= 0;
-  var stackTrace = StackTrace.current;
-  return new LazyTrace(() {
-    // Ignore the VM's stack chains when we generate our own. Otherwise we'll
-    // end up with duplicate frames all over the place.
-    var text = stackTrace.toString();
-    var index = text.indexOf(vmChainGap);
-    if (index != -1) text = text.substring(0, index);
-
-    var trace = new Trace.parse(text);
-    // JS includes a frame for the call to StackTrace.current, but the VM
-    // doesn't, so we skip an extra frame in a JS context.
-    return new Trace(trace.frames.skip(level + (inJS ? 2 : 1)), original: text);
-  });
 }

--- a/lib/src/stack_zone_specification.dart
+++ b/lib/src/stack_zone_specification.dart
@@ -86,7 +86,7 @@ class StackZoneSpecification {
   /// with [trace], this just returns a single-trace chain containing [trace].
   Chain chainFor(StackTrace trace) {
     if (trace is Chain) return trace;
-    var previous = trace == null ? null : _chains[trace];
+    var previous = (trace == null ? null : _chains[trace]) ?? _currentNode;
     return new _Node(trace, previous).toChain();
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ name: stack_trace
 #
 # When the major version is upgraded, you *must* update that version constraint
 # in pub to stay in sync with this.
-version: 1.8.3-dev
+version: 1.8.3
 author: "Dart Team <misc@dartlang.org>"
 homepage: https://github.com/dart-lang/stack_trace
 description: A package for manipulating stack traces and printing them readably.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ name: stack_trace
 #
 # When the major version is upgraded, you *must* update that version constraint
 # in pub to stay in sync with this.
-version: 1.8.2
+version: 1.8.3-dev
 author: "Dart Team <misc@dartlang.org>"
 homepage: https://github.com/dart-lang/stack_trace
 description: A package for manipulating stack traces and printing them readably.

--- a/test/chain/vm_test.dart
+++ b/test/chain/vm_test.dart
@@ -18,12 +18,21 @@ import 'utils.dart';
 
 void main() {
   group('capture() with onError catches exceptions', () {
-    test('thrown synchronously', () {
-      return captureFuture(() => throw 'error').then((chain) {
-        expect(chain.traces, hasLength(1));
-        expect(
-            chain.traces.single.frames.first, frameMember(startsWith('main')));
+    test('thrown synchronously', () async {
+      StackTrace vmTrace;
+      var chain = await captureFuture(() {
+        try {
+          throw 'error';
+        } catch (_, stackTrace) {
+          vmTrace = stackTrace;
+          rethrow;
+        }
       });
+
+      // Because there's no chain context for a synchronous error, we fall back
+      // on the VM's stack chain tracking.
+      expect(chain.toString(),
+          equals(new Chain.parse(vmTrace.toString()).toString()));
     });
 
     test('thrown in a microtask', () {

--- a/test/chain/vm_test.dart
+++ b/test/chain/vm_test.dart
@@ -468,8 +468,11 @@ void main() {
       });
 
       expect(chain.traces, hasLength(2));
+
+      // Assert that we've trimmed the VM's stack chains here to avoid
+      // duplication.
       expect(chain.traces.first.toString(),
-          equals(new Trace.from(trace).toString()));
+          equals(new Chain.parse(trace.toString()).traces.first.toString()));
       expect(
           chain.traces.last.frames, contains(frameMember(startsWith('main'))));
     });


### PR DESCRIPTION
This more consistently uses stack_trace's chains when they're
available, and falls back on VM chains when they aren't. This was
always the policy, but we were missing some edge cases.