### PR TITLE
Added a Trace.v8Trace getter to return V8-style stack trace

### DIFF
--- a/lib/src/lazy_trace.dart
+++ b/lib/src/lazy_trace.dart
@@ -25,6 +25,7 @@ class LazyTrace implements Trace {
   List<Frame> get frames => _trace.frames;
   StackTrace get original => _trace.original;
   StackTrace get vmTrace => _trace.vmTrace;
+  String get v8Trace => _trace.v8Trace;
   Trace get terse => new LazyTrace(() => _trace.terse);
   Trace foldFrames(bool predicate(Frame frame), {bool terse: false}) =>
       new LazyTrace(() => _trace.foldFrames(predicate, terse: terse));

--- a/test/trace_test.dart
+++ b/test/trace_test.dart
@@ -287,6 +287,22 @@ http://pub.dartlang.org/thing.dart 1:100  zip.<fn>.zap
             '#3      baz (dart:async:15:0)\n'));
   });
 
+  test('.v8Trace returns a v8-style trace', () {
+    final trace = new Trace.parse('''
+#1 top (dart:async/future.dart:0:2)
+#2 bottom (dart:core/uri.dart:1:100)
+#3 fooBottom (package:foo/bar.dart:0:2)
+#4 App.main (foo.dart:42:21)
+''');
+
+    expect(trace.v8Trace, equals('''Error:
+    at top (native)
+    at bottom (native)
+    at fooBottom (package:foo/bar.dart:0:2)
+    at App.main (foo.dart:42:21)
+'''));
+  });
+
   group("folding", () {
     group(".terse", () {
       test('folds core frames together bottom-up', () {


### PR DESCRIPTION
Hmm, I'm not sure this is the best place for this logic... it's possible I should just put it in a different package.

The motivation is to have formatting support for sending exceptions to stack driver error reporting service:
https://cloud.google.com/error-reporting/reference/rest/v1beta1/projects.events/report#reportederrorevent

I think this would be useful for other servies too... hmm, maybe it could also be useful for stack traces going into javascript world... Like I said, I wouldn't be offended if someone said this wasn't a good fit for this package :)