### PR TITLE
Use `runZonedGuarded` when using an error handler. 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: dart
 
 dart:
   - dev
-  - stable
 
 dart_task:
   - test: -p vm

--- a/lib/src/chain.dart
+++ b/lib/src/chain.dart
@@ -53,7 +53,7 @@ class Chain implements StackTrace {
   /// stack chain is tracked and automatically associated with (most) errors.
   ///
   /// If [when] is `false`, this does not track stack chains. Instead, it's
-  /// identical to [runZoned], except that it wraps any errors in [new
+  /// identical to [runZonedGuarded], except that it wraps any errors in [new
   /// Chain.forTrace]—which will only wrap the trace unless there's a different
   /// [Chain.capture] active. This makes it easy for the caller to only capture
   /// stack chains in debug mode or during development.
@@ -92,7 +92,7 @@ class Chain implements StackTrace {
         };
       }
 
-      return runZoned(callback, onError: newOnError);
+      return runZonedGuarded(callback, newOnError);
     }
 
     var spec = new StackZoneSpecification(onError, errorZone: errorZone);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,14 +7,14 @@ name: stack_trace
 #
 # When the major version is upgraded, you *must* update that version constraint
 # in pub to stay in sync with this.
-version: 1.9.3
+version: 1.9.4
 
 description: A package for manipulating stack traces and printing them readably.
 author: 'Dart Team <misc@dartlang.org>'
 homepage: https://github.com/dart-lang/stack_trace
 
 environment:
-  sdk: '>=1.23.0 <3.0.0'
+  sdk: '>=2.8.0-dev <3.0.0'
 
 dependencies:
   path: ^1.2.0

--- a/test/chain/dart2js_test.dart
+++ b/test/chain/dart2js_test.dart
@@ -140,7 +140,7 @@ void main() {
     test('and relays them to the parent zone', () {
       var completer = new Completer();
 
-      runZoned(() {
+      runZonedGuarded(() {
         Chain.capture(() {
           inMicrotask(() => throw 'error');
         }, onError: (error, chain) {
@@ -148,7 +148,7 @@ void main() {
           expect(chain.traces, hasLength(2));
           throw error;
         });
-      }, onError: (error, chain) {
+      }, (error, chain) {
         try {
           expect(error, equals('error'));
           expect(chain, new isInstanceOf<Chain>());
@@ -166,9 +166,9 @@ void main() {
   test('capture() without onError passes exceptions to parent zone', () {
     var completer = new Completer();
 
-    runZoned(() {
+    runZonedGuarded(() {
       Chain.capture(() => inMicrotask(() => throw 'error'));
-    }, onError: (error, chain) {
+    }, (error, chain) {
       try {
         expect(error, equals('error'));
         expect(chain, new isInstanceOf<Chain>());

--- a/test/chain/vm_test.dart
+++ b/test/chain/vm_test.dart
@@ -234,7 +234,7 @@ void main() {
     test('and relays them to the parent zone', () {
       var completer = new Completer();
 
-      runZoned(() {
+      runZonedGuarded(() {
         Chain.capture(() {
           inMicrotask(() => throw 'error');
         }, onError: (error, chain) {
@@ -243,7 +243,7 @@ void main() {
               contains(frameMember(startsWith('inMicrotask'))));
           throw error;
         });
-      }, onError: (error, chain) {
+      }, (error, chain) {
         try {
           expect(error, equals('error'));
           expect(chain, new isInstanceOf<Chain>());
@@ -262,9 +262,9 @@ void main() {
   test('capture() without onError passes exceptions to parent zone', () {
     var completer = new Completer();
 
-    runZoned(() {
+    runZonedGuarded(() {
       Chain.capture(() => inMicrotask(() => throw 'error'));
-    }, onError: (error, chain) {
+    }, (error, chain) {
       try {
         expect(error, equals('error'));
         expect(chain, new isInstanceOf<Chain>());


### PR DESCRIPTION
Needed for NNBD SDK compatibility.

@kevmoo Not sure who owns this package now.