### PR TITLE
Make StackTrace non-null

### DIFF
--- a/lib/src/stack_zone_specification.dart
+++ b/lib/src/stack_zone_specification.dart
@@ -145,7 +145,7 @@ class StackZoneSpecification {
   /// Looks up the chain associated with [stackTrace] and passes it either to
   /// [_onError] or [parent]'s error handler.
   void _handleUncaughtError(
-      Zone self, ZoneDelegate parent, Zone zone, error, StackTrace? stackTrace) {
+      Zone self, ZoneDelegate parent, Zone zone, error, StackTrace stackTrace) {
     if (_disabled) {
       parent.handleUncaughtError(zone, error, stackTrace);
       return;


### PR DESCRIPTION
Fixes a new static error now that the StackTrace is non-null in the SDK.