### PR TITLE
Test on oldest supported SDK

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: dart
 
 dart:
   - dev
-  - stable
   - 2.0.0
 
 dart_task:
@@ -18,9 +17,6 @@ matrix:
     - dart: dev
       dart_task:
         dartanalyzer: --fatal-infos --fatal-warnings .
-    - dart: stable
-      dart_task:
-        dartanalyzer: --fatal-warnings .
     - dart: 2.0.0
       dart_task:
         dartanalyzer: --fatal-warnings .

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: dart
 dart:
   - dev
   - stable
+  - 2.0.0
 
 dart_task:
   - test: -p vm
@@ -12,9 +13,17 @@ dart_task:
 matrix:
   include:
     # Only validate formatting using the dev release
-    # Formatted with 1.23.0+ which has (good) changes since 1.22.1
     - dart: dev
       dart_task: dartfmt
+    - dart: dev
+      dart_task:
+        dartanalyzer: --fatal-infos --fatal-warnings .
+    - dart: stable
+      dart_task:
+        dartanalyzer: --fatal-warnings .
+    - dart: 2.0.0
+      dart_task:
+        dartanalyzer: --fatal-warnings .
 
 # Only building master means that we don't run two builds for each pull request.
 branches:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ author: 'Dart Team <misc@dartlang.org>'
 homepage: https://github.com/dart-lang/stack_trace
 
 environment:
-  sdk: '>=1.23.0 <3.0.0'
+  sdk: '>=2.0.0 <3.0.0'
 
 dependencies:
   path: ^1.2.0

--- a/test/chain/chain_test.dart
+++ b/test/chain/chain_test.dart
@@ -44,7 +44,7 @@ void main() {
         return new Future.error("oh no");
       }, onError: expectAsync2((error, chain) {
         expect(error, equals("oh no"));
-        expect(chain, isA<Chain>());
+        expect(chain, TypeMatcher<Chain>());
       }));
     });
 
@@ -55,7 +55,7 @@ void main() {
         future.then(expectAsync1((_) {}, count: 0));
       }, onError: expectAsync2((error, chain) {
         expect(error, equals("oh no"));
-        expect(chain, isA<Chain>());
+        expect(chain, TypeMatcher<Chain>());
       }));
     });
 
@@ -80,7 +80,7 @@ void main() {
           return new Future.error("oh no");
         }, onError: expectAsync2((error, chain) {
           expect(error, equals("oh no"));
-          expect(chain, isA<Chain>());
+          expect(chain, TypeMatcher<Chain>());
         }), when: false);
       });
 

--- a/test/chain/chain_test.dart
+++ b/test/chain/chain_test.dart
@@ -44,7 +44,7 @@ void main() {
         return new Future.error("oh no");
       }, onError: expectAsync2((error, chain) {
         expect(error, equals("oh no"));
-        expect(chain, new isInstanceOf<Chain>());
+        expect(chain, isA<Chain>());
       }));
     });
 
@@ -55,7 +55,7 @@ void main() {
         future.then(expectAsync1((_) {}, count: 0));
       }, onError: expectAsync2((error, chain) {
         expect(error, equals("oh no"));
-        expect(chain, new isInstanceOf<Chain>());
+        expect(chain, isA<Chain>());
       }));
     });
 
@@ -80,7 +80,7 @@ void main() {
           return new Future.error("oh no");
         }, onError: expectAsync2((error, chain) {
           expect(error, equals("oh no"));
-          expect(chain, new isInstanceOf<Chain>());
+          expect(chain, isA<Chain>());
         }), when: false);
       });
 

--- a/test/chain/dart2js_test.dart
+++ b/test/chain/dart2js_test.dart
@@ -151,7 +151,7 @@ void main() {
       }, onError: (error, chain) {
         try {
           expect(error, equals('error'));
-          expect(chain, new isInstanceOf<Chain>());
+          expect(chain, isA<Chain>());
           expect(chain.traces, hasLength(2));
           completer.complete();
         } catch (error, stackTrace) {
@@ -171,7 +171,7 @@ void main() {
     }, onError: (error, chain) {
       try {
         expect(error, equals('error'));
-        expect(chain, new isInstanceOf<Chain>());
+        expect(chain, isA<Chain>());
         expect(chain.traces, hasLength(2));
         completer.complete();
       } catch (error, stackTrace) {

--- a/test/chain/dart2js_test.dart
+++ b/test/chain/dart2js_test.dart
@@ -171,7 +171,7 @@ void main() {
     }, onError: (error, chain) {
       try {
         expect(error, equals('error'));
-        expect(chain, isA<Chain>());
+        expect(chain, TypeMatcher<Chain>());
         expect(chain.traces, hasLength(2));
         completer.complete();
       } catch (error, stackTrace) {

--- a/test/chain/dart2js_test.dart
+++ b/test/chain/dart2js_test.dart
@@ -151,7 +151,7 @@ void main() {
       }, onError: (error, chain) {
         try {
           expect(error, equals('error'));
-          expect(chain, isA<Chain>());
+          expect(chain, TypeMatcher<Chain>());
           expect(chain.traces, hasLength(2));
           completer.complete();
         } catch (error, stackTrace) {

--- a/test/chain/vm_test.dart
+++ b/test/chain/vm_test.dart
@@ -246,7 +246,7 @@ void main() {
       }, onError: (error, chain) {
         try {
           expect(error, equals('error'));
-          expect(chain, isA<Chain>());
+          expect(chain, TypeMatcher<Chain>());
           expect(chain.traces[1].frames,
               contains(frameMember(startsWith('inMicrotask'))));
           completer.complete();
@@ -267,7 +267,7 @@ void main() {
     }, onError: (error, chain) {
       try {
         expect(error, equals('error'));
-        expect(chain, isA<Chain>());
+        expect(chain, TypeMatcher<Chain>());
         expect(chain.traces[1].frames,
             contains(frameMember(startsWith('inMicrotask'))));
         completer.complete();

--- a/test/chain/vm_test.dart
+++ b/test/chain/vm_test.dart
@@ -246,7 +246,7 @@ void main() {
       }, onError: (error, chain) {
         try {
           expect(error, equals('error'));
-          expect(chain, new isInstanceOf<Chain>());
+          expect(chain, isA<Chain>());
           expect(chain.traces[1].frames,
               contains(frameMember(startsWith('inMicrotask'))));
           completer.complete();
@@ -267,7 +267,7 @@ void main() {
     }, onError: (error, chain) {
       try {
         expect(error, equals('error'));
-        expect(chain, new isInstanceOf<Chain>());
+        expect(chain, isA<Chain>());
         expect(chain.traces[1].frames,
             contains(frameMember(startsWith('inMicrotask'))));
         completer.complete();

--- a/test/frame_test.dart
+++ b/test/frame_test.dart
@@ -659,6 +659,6 @@ baz@http://pub.dartlang.org/buz.js:56355:55
 
 void expectIsUnparsed(Frame constructor(String text), String text) {
   var frame = constructor(text);
-  expect(frame, new isInstanceOf<UnparsedFrame>());
+  expect(frame, isA<UnparsedFrame>());
   expect(frame.toString(), equals(text));
 }

--- a/test/frame_test.dart
+++ b/test/frame_test.dart
@@ -659,6 +659,6 @@ baz@http://pub.dartlang.org/buz.js:56355:55
 
 void expectIsUnparsed(Frame constructor(String text), String text) {
   var frame = constructor(text);
-  expect(frame, isA<UnparsedFrame>());
+  expect(frame, TypeMatcher<UnparsedFrame>());
   expect(frame.toString(), equals(text));
 }


### PR DESCRIPTION
- Bump min SDK to 2.0.0
- Run tests and analyzer `--fatal-warnings` on 2.0.0 and the stable SDK.
- Run tests, dartfmt check, and analyzer `--fatal-infos` on the dev SDK.