### PR TITLE
Clean up pubspec

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,16 +1,6 @@
 name: stack_trace
-
-# Note! This version number is referenced directly in the pub source code in
-# lib/src/barback.dart. Pub implicitly places a version constraint on
-# stack_trace to ensure users only select a version of stack_trace that works
-# with their current version of pub.
-#
-# When the major version is upgraded, you *must* update that version constraint
-# in pub to stay in sync with this.
 version: 1.9.4-dev
-
 description: A package for manipulating stack traces and printing them readably.
-author: 'Dart Team <misc@dartlang.org>'
 homepage: https://github.com/dart-lang/stack_trace
 
 environment:


### PR DESCRIPTION
- Remove stale comment about barback. Pub no longer forces tight
  constraints on this package.
- Remove unused author field.
- Remove some unnecessary newlines.