### PR TITLE
Enable and fix package:pedantic lints

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,10 +1,6 @@
+include: package:pedantic/analysis_options.yaml
 analyzer:
   strong-mode:
     implicit-casts: false
-linter:
-  rules:
-    - prefer_equal_for_default_values
-    - prefer_generic_function_type_aliases
-    - slash_for_doc_comments
-    - unnecessary_const
-    - unnecessary_new
+  errors:
+    prefer_spread_collections: ignore

--- a/lib/src/chain.dart
+++ b/lib/src/chain.dart
@@ -12,7 +12,7 @@ import 'trace.dart';
 import 'utils.dart';
 
 /// A function that handles errors in the zone wrapped by [Chain.capture].
-@Deprecated("Will be removed in stack_trace 2.0.0.")
+@Deprecated('Will be removed in stack_trace 2.0.0.')
 typedef ChainHandler = void Function(dynamic error, Chain chain);
 
 /// An opaque key used to track the current [StackZoneSpecification].
@@ -72,13 +72,13 @@ class Chain implements StackTrace {
   /// `false`, [onError] must be `null`.
   ///
   /// If [callback] returns a value, it will be returned by [capture] as well.
-  static T capture<T>(T callback(),
-      {void onError(error, Chain chain),
+  static T capture<T>(T Function() callback,
+      {void Function(Object error, Chain) onError,
       bool when = true,
       bool errorZone = true}) {
     if (!errorZone && onError != null) {
       throw ArgumentError.value(
-          onError, "onError", "must be null if errorZone is false");
+          onError, 'onError', 'must be null if errorZone is false');
     }
 
     if (!when) {
@@ -114,7 +114,7 @@ class Chain implements StackTrace {
   /// [callback] in a [Zone] in which chain capturing is disabled.
   ///
   /// If [callback] returns a value, it will be returned by [disable] as well.
-  static T disable<T>(T callback(), {bool when = true}) {
+  static T disable<T>(T Function() callback, {bool when = true}) {
     var zoneValues =
         when ? {_specKey: null, StackZoneSpecification.disableKey: true} : null;
 
@@ -126,8 +126,8 @@ class Chain implements StackTrace {
   /// Prior to Dart 1.7, this was necessary to ensure that stack traces for
   /// exceptions reported with [Completer.completeError] and
   /// [StreamController.addError] were tracked correctly.
-  @Deprecated("Chain.track is not necessary in Dart 1.7+.")
-  static track(futureOrStream) => futureOrStream;
+  @Deprecated('Chain.track is not necessary in Dart 1.7+.')
+  static dynamic track(futureOrStream) => futureOrStream;
 
   /// Returns the current stack chain.
   ///
@@ -211,7 +211,7 @@ class Chain implements StackTrace {
   /// If [terse] is true, this will also fold together frames from the core
   /// library or from this package, and simplify core library frames as in
   /// [Trace.terse].
-  Chain foldFrames(bool predicate(Frame frame), {bool terse = false}) {
+  Chain foldFrames(bool Function(Frame) predicate, {bool terse = false}) {
     var foldedTraces =
         traces.map((trace) => trace.foldFrames(predicate, terse: terse));
     var nonEmptyTraces = foldedTraces.where((trace) {
@@ -241,6 +241,7 @@ class Chain implements StackTrace {
   /// in the chain.
   Trace toTrace() => Trace(traces.expand((trace) => trace.frames));
 
+  @override
   String toString() {
     // Figure out the longest path so we know how much to pad.
     var longest = traces.map((trace) {

--- a/lib/src/frame.dart
+++ b/lib/src/frame.dart
@@ -33,7 +33,7 @@ final _v8EvalLocation =
 // anonymous/<@http://pub.dartlang.org/stuff.js line 693 > Function:3:40
 // anonymous/<@http://pub.dartlang.org/stuff.js line 693 > eval:3:40
 final _firefoxEvalLocation =
-    RegExp(r"(\S+)@(\S+) line (\d+) >.* (Function|eval):\d+:\d+");
+    RegExp(r'(\S+)@(\S+) line (\d+) >.* (Function|eval):\d+:\d+');
 
 // .VW.call$0@http://pub.dartlang.org/stuff.dart.js:560
 // .VW.call$0("arg")@http://pub.dartlang.org/stuff.dart.js:560
@@ -65,7 +65,7 @@ final _friendlyFrame = RegExp(r'^(\S+)(?: (\d+)(?::(\d+))?)?\s+([^\d].*)$');
 /// VM.
 final _asyncBody = RegExp(r'<(<anonymous closure>|[^>]+)_async_body>');
 
-final _initialDot = RegExp(r"^\.");
+final _initialDot = RegExp(r'^\.');
 
 /// A single stack frame. Each frame points to a precise location in Dart code.
 class Frame {
@@ -100,7 +100,7 @@ class Frame {
   /// This will usually be the string form of [uri], but a relative URI will be
   /// used if possible. Data URIs will be truncated.
   String get library {
-    if (uri.scheme == 'data') return "data:...";
+    if (uri.scheme == 'data') return 'data:...';
     return path.prettyUri(uri);
   }
 
@@ -125,8 +125,8 @@ class Frame {
   /// higher than `1`, it will return higher frames.
   factory Frame.caller([int level = 1]) {
     if (level < 0) {
-      throw ArgumentError("Argument [level] must be greater than or equal "
-          "to 0.");
+      throw ArgumentError('Argument [level] must be greater than or equal '
+          'to 0.');
     }
 
     return Trace.current(level + 1).frames.first;
@@ -146,8 +146,8 @@ class Frame {
         // Get the pieces out of the regexp match. Function, URI and line should
         // always be found. The column is optional.
         var member = match[1]
-            .replaceAll(_asyncBody, "<async>")
-            .replaceAll("<anonymous closure>", "<fn>");
+            .replaceAll(_asyncBody, '<async>')
+            .replaceAll('<anonymous closure>', '<fn>');
         var uri = Uri.parse(match[2]);
 
         var lineAndColumn = match[3].split(':');
@@ -191,13 +191,13 @@ class Frame {
           return parseLocation(
               match[2],
               match[1]
-                  .replaceAll("<anonymous>", "<fn>")
-                  .replaceAll("Anonymous function", "<fn>")
-                  .replaceAll("(anonymous function)", "<fn>"));
+                  .replaceAll('<anonymous>', '<fn>')
+                  .replaceAll('Anonymous function', '<fn>')
+                  .replaceAll('(anonymous function)', '<fn>'));
         } else {
           // The second form looks like " at LOCATION", and is used for
           // anonymous functions.
-          return parseLocation(match[3], "<fn>");
+          return parseLocation(match[3], '<fn>');
         }
       });
 
@@ -244,7 +244,7 @@ class Frame {
         if (match[1] != null) {
           member = match[1];
           member +=
-              List.filled('/'.allMatches(match[2]).length, ".<fn>").join();
+              List.filled('/'.allMatches(match[2]).length, '.<fn>').join();
           if (member == '') member = '<fn>';
 
           // Some Firefox members have initial dots. We remove them for
@@ -261,11 +261,11 @@ class Frame {
       });
 
   /// Parses a string representation of a Safari 6.0 stack frame.
-  @Deprecated("Use Frame.parseSafari instead.")
+  @Deprecated('Use Frame.parseSafari instead.')
   factory Frame.parseSafari6_0(String frame) => Frame.parseFirefox(frame);
 
   /// Parses a string representation of a Safari 6.1+ stack frame.
-  @Deprecated("Use Frame.parseSafari instead.")
+  @Deprecated('Use Frame.parseSafari instead.')
   factory Frame.parseSafari6_1(String frame) => Frame.parseFirefox(frame);
 
   /// Parses a string representation of a Safari stack frame.
@@ -323,7 +323,7 @@ class Frame {
   ///
   /// If [body] throws a [FormatException], returns an [UnparsedFrame] with
   /// [text] instead.
-  static Frame _catchFormatException(String text, Frame body()) {
+  static Frame _catchFormatException(String text, Frame Function() body) {
     try {
       return body();
     } on FormatException catch (_) {
@@ -333,5 +333,6 @@ class Frame {
 
   Frame(this.uri, this.line, this.column, this.member);
 
+  @override
   String toString() => '$location in $member';
 }

--- a/lib/src/lazy_chain.dart
+++ b/lib/src/lazy_chain.dart
@@ -19,15 +19,17 @@ class LazyChain implements Chain {
 
   LazyChain(this._thunk);
 
-  Chain get _chain {
-    if (_inner == null) _inner = _thunk();
-    return _inner;
-  }
+  Chain get _chain => _inner ??= _thunk();
 
+  @override
   List<Trace> get traces => _chain.traces;
+  @override
   Chain get terse => _chain.terse;
-  Chain foldFrames(bool predicate(Frame frame), {bool terse = false}) =>
+  @override
+  Chain foldFrames(bool Function(Frame) predicate, {bool terse = false}) =>
       LazyChain(() => _chain.foldFrames(predicate, terse: terse));
+  @override
   Trace toTrace() => LazyTrace(() => _chain.toTrace());
+  @override
   String toString() => _chain.toString();
 }

--- a/lib/src/lazy_trace.dart
+++ b/lib/src/lazy_trace.dart
@@ -17,17 +17,20 @@ class LazyTrace implements Trace {
 
   LazyTrace(this._thunk);
 
-  Trace get _trace {
-    if (_inner == null) _inner = _thunk();
-    return _inner;
-  }
+  Trace get _trace => _inner ??= _thunk();
 
+  @override
   List<Frame> get frames => _trace.frames;
+  @override
   StackTrace get original => _trace.original;
+  @override
   StackTrace get vmTrace => _trace.vmTrace;
+  @override
   Trace get terse => LazyTrace(() => _trace.terse);
-  Trace foldFrames(bool predicate(Frame frame), {bool terse = false}) =>
+  @override
+  Trace foldFrames(bool Function(Frame) predicate, {bool terse = false}) =>
       LazyTrace(() => _trace.foldFrames(predicate, terse: terse));
+  @override
   String toString() => _trace.toString();
 
   // Work around issue 14075.

--- a/lib/src/stack_zone_specification.dart
+++ b/lib/src/stack_zone_specification.dart
@@ -50,7 +50,7 @@ class StackZoneSpecification {
   ///
   /// The chain associated with a given stack trace doesn't contain a node for
   /// that stack trace.
-  final _chains = Expando<_Node>("stack chains");
+  final _chains = Expando<_Node>('stack chains');
 
   /// The error handler for the zone.
   ///
@@ -113,7 +113,7 @@ class StackZoneSpecification {
   /// Tracks the current stack chain so it can be set to [_currentChain] when
   /// [f] is run.
   ZoneCallback<R> _registerCallback<R>(
-      Zone self, ZoneDelegate parent, Zone zone, R f()) {
+      Zone self, ZoneDelegate parent, Zone zone, R Function() f) {
     if (f == null || _disabled) return parent.registerCallback(zone, f);
     var node = _createNode(1);
     return parent.registerCallback(zone, () => _run(f, node));
@@ -122,7 +122,7 @@ class StackZoneSpecification {
   /// Tracks the current stack chain so it can be set to [_currentChain] when
   /// [f] is run.
   ZoneUnaryCallback<R, T> _registerUnaryCallback<R, T>(
-      Zone self, ZoneDelegate parent, Zone zone, R f(T arg)) {
+      Zone self, ZoneDelegate parent, Zone zone, R Function(T) f) {
     if (f == null || _disabled) return parent.registerUnaryCallback(zone, f);
     var node = _createNode(1);
     return parent.registerUnaryCallback(zone, (arg) {
@@ -184,7 +184,7 @@ class StackZoneSpecification {
     }
 
     var asyncError = parent.errorCallback(zone, error, stackTrace);
-    return asyncError == null ? AsyncError(error, stackTrace) : asyncError;
+    return asyncError ?? AsyncError(error, stackTrace);
   }
 
   /// Creates a [_Node] with the current stack trace and linked to
@@ -202,7 +202,7 @@ class StackZoneSpecification {
   ///
   /// If [f] throws an error, this associates [node] with that error's stack
   /// trace.
-  T _run<T>(T f(), _Node node) {
+  T _run<T>(T Function() f, _Node node) {
     var previousNode = _currentNode;
     _currentNode = node;
     try {

--- a/lib/src/trace.dart
+++ b/lib/src/trace.dart
@@ -11,7 +11,7 @@ import 'unparsed_frame.dart';
 import 'utils.dart';
 import 'vm_trace.dart';
 
-final _terseRegExp = RegExp(r"(-patch)?([/\\].*)?$");
+final _terseRegExp = RegExp(r'(-patch)?([/\\].*)?$');
 
 /// A RegExp to match V8's stack traces.
 ///
@@ -19,13 +19,13 @@ final _terseRegExp = RegExp(r"(-patch)?([/\\].*)?$");
 /// description of the exception that occurred. That description can be multiple
 /// lines, so we just look for any line other than the first that begins with
 /// three or four spaces and "at".
-final _v8Trace = RegExp(r"\n    ?at ");
+final _v8Trace = RegExp(r'\n    ?at ');
 
 /// A RegExp to match indidual lines of V8's stack traces.
 ///
 /// This is intended to filter out the leading exception details of the trace
 /// though it is possible for the message to match this as well.
-final _v8TraceLine = RegExp(r"    ?at ");
+final _v8TraceLine = RegExp(r'    ?at ');
 
 /// A RegExp to match Firefox's eval and Function stack traces.
 ///
@@ -34,7 +34,7 @@ final _v8TraceLine = RegExp(r"    ?at ");
 /// These stack traces looks like:
 ///     anonymous/<@http://pub.dartlang.org/stuff.js line 693 > Function:3:40
 ///     anonymous/<@http://pub.dartlang.org/stuff.js line 693 > eval:3:40
-final _firefoxEvalTrace = RegExp(r"@\S+ line \d+ >.* (Function|eval):\d+:\d+");
+final _firefoxEvalTrace = RegExp(r'@\S+ line \d+ >.* (Function|eval):\d+:\d+');
 
 /// A RegExp to match Firefox and Safari's stack traces.
 ///
@@ -50,19 +50,19 @@ final _firefoxEvalTrace = RegExp(r"@\S+ line \d+ >.* (Function|eval):\d+:\d+");
 /// trailing colon if no column number is available). They can also contain
 /// empty lines or lines consisting only of `[native code]`.
 final _firefoxSafariTrace = RegExp(
-    r"^"
-    r"(" // Member description. Not present in some Safari frames.
-    r"([.0-9A-Za-z_$/<]|\(.*\))*" // Member name and arguments.
-    r"@"
-    r")?"
-    r"[^\s]*" // Frame URL.
-    r":\d*" // Line or column number. Some older frames only have a line number.
-    r"$",
+    r'^'
+    r'(' // Member description. Not present in some Safari frames.
+    r'([.0-9A-Za-z_$/<]|\(.*\))*' // Member name and arguments.
+    r'@'
+    r')?'
+    r'[^\s]*' // Frame URL.
+    r':\d*' // Line or column number. Some older frames only have a line number.
+    r'$',
     multiLine: true);
 
 /// A RegExp to match this package's stack traces.
 final _friendlyTrace =
-    RegExp(r"^[^\s<][^\s]*( \d+(:\d+)?)?[ \t]+[^\s]+$", multiLine: true);
+    RegExp(r'^[^\s<][^\s]*( \d+(:\d+)?)?[ \t]+[^\s]+$', multiLine: true);
 
 /// A stack trace, comprised of a list of stack frames.
 class Trace implements StackTrace {
@@ -89,8 +89,8 @@ class Trace implements StackTrace {
   /// many frames up instead.
   factory Trace.current([int level = 0]) {
     if (level < 0) {
-      throw ArgumentError("Argument [level] must be greater than or equal "
-          "to 0.");
+      throw ArgumentError('Argument [level] must be greater than or equal '
+          'to 0.');
     }
 
     var trace = Trace.from(StackTrace.current);
@@ -111,7 +111,7 @@ class Trace implements StackTrace {
     // the natural failure will only occur when the LazyTrace is materialized,
     // and we want to provide an error that's more local to the actual problem.
     if (trace == null) {
-      throw ArgumentError("Cannot create a Trace from null.");
+      throw ArgumentError('Cannot create a Trace from null.');
     }
 
     if (trace is Trace) return trace;
@@ -128,7 +128,7 @@ class Trace implements StackTrace {
     try {
       if (trace.isEmpty) return Trace(<Frame>[]);
       if (trace.contains(_v8Trace)) return Trace.parseV8(trace);
-      if (trace.contains("\tat ")) return Trace.parseJSCore(trace);
+      if (trace.contains('\tat ')) return Trace.parseJSCore(trace);
       if (trace.contains(_firefoxSafariTrace) ||
           trace.contains(_firefoxEvalTrace)) {
         return Trace.parseFirefox(trace);
@@ -153,14 +153,14 @@ class Trace implements StackTrace {
   static List<Frame> _parseVM(String trace) {
     // Ignore [vmChainGap]. This matches the behavior of
     // `Chain.parse().toTrace()`.
-    var lines = trace.trim().replaceAll(vmChainGap, '').split("\n");
+    var lines = trace.trim().replaceAll(vmChainGap, '').split('\n');
     var frames = lines
         .take(lines.length - 1)
         .map((line) => Frame.parseVM(line))
         .toList();
 
     // TODO(nweiz): Remove this when issue 23614 is fixed.
-    if (!lines.last.endsWith(".da")) {
+    if (!lines.last.endsWith('.da')) {
       frames.add(Frame.parseVM(lines.last));
     }
 
@@ -171,7 +171,7 @@ class Trace implements StackTrace {
   Trace.parseV8(String trace)
       : this(
             trace
-                .split("\n")
+                .split('\n')
                 .skip(1)
                 // It's possible that an Exception's description contains a line
                 // that looks like a V8 trace line, which will screw this up.
@@ -184,8 +184,8 @@ class Trace implements StackTrace {
   Trace.parseJSCore(String trace)
       : this(
             trace
-                .split("\n")
-                .where((line) => line != "\tat ")
+                .split('\n')
+                .where((line) => line != '\tat ')
                 .map((line) => Frame.parseV8(line)),
             original: trace);
 
@@ -200,7 +200,7 @@ class Trace implements StackTrace {
       : this(
             trace
                 .trim()
-                .split("\n")
+                .split('\n')
                 .where((line) => line.isNotEmpty && line != '[native code]')
                 .map((line) => Frame.parseFirefox(line)),
             original: trace);
@@ -209,16 +209,16 @@ class Trace implements StackTrace {
   Trace.parseSafari(String trace) : this.parseFirefox(trace);
 
   /// Parses a string representation of a Safari 6.1+ stack trace.
-  @Deprecated("Use Trace.parseSafari instead.")
+  @Deprecated('Use Trace.parseSafari instead.')
   Trace.parseSafari6_1(String trace) : this.parseSafari(trace);
 
   /// Parses a string representation of a Safari 6.0 stack trace.
-  @Deprecated("Use Trace.parseSafari instead.")
+  @Deprecated('Use Trace.parseSafari instead.')
   Trace.parseSafari6_0(String trace)
       : this(
             trace
                 .trim()
-                .split("\n")
+                .split('\n')
                 .where((line) => line != '[native code]')
                 .map((line) => Frame.parseFirefox(line)),
             original: trace);
@@ -233,7 +233,7 @@ class Trace implements StackTrace {
                 ? []
                 : trace
                     .trim()
-                    .split("\n")
+                    .split('\n')
                     // Filter out asynchronous gaps from [Chain]s.
                     .where((line) => !line.startsWith('====='))
                     .map((line) => Frame.parseFriendly(line)),
@@ -280,7 +280,7 @@ class Trace implements StackTrace {
   /// If [terse] is true, this will also fold together frames from the core
   /// library or from this package, simplify core library frames, and
   /// potentially remove the outermost frame as in [Trace.terse].
-  Trace foldFrames(bool predicate(Frame frame), {bool terse = false}) {
+  Trace foldFrames(bool Function(Frame) predicate, {bool terse = false}) {
     if (terse) {
       var oldPredicate = predicate;
       predicate = (frame) {
@@ -322,10 +322,10 @@ class Trace implements StackTrace {
       }
     }
 
-    return Trace(newFrames.reversed, original: this.original.toString());
+    return Trace(newFrames.reversed, original: original.toString());
   }
 
-  /// Returns a human-readable string representation of [this].
+  @override
   String toString() {
     // Figure out the longest path so we know how much to pad.
     var longest =
@@ -333,7 +333,7 @@ class Trace implements StackTrace {
 
     // Print out the stack trace nicely formatted.
     return frames.map((frame) {
-      if (frame is UnparsedFrame) return "$frame\n";
+      if (frame is UnparsedFrame) return '$frame\n';
       return '${frame.location.padRight(longest)}  ${frame.member}\n';
     }).join();
   }

--- a/lib/src/unparsed_frame.dart
+++ b/lib/src/unparsed_frame.dart
@@ -8,17 +8,26 @@ import 'frame.dart';
 ///
 /// The [member] property contains the original frame's contents.
 class UnparsedFrame implements Frame {
-  final Uri uri = Uri(path: "unparsed");
+  @override
+  final Uri uri = Uri(path: 'unparsed');
+  @override
   final int line = null;
+  @override
   final int column = null;
+  @override
   final bool isCore = false;
-  final String library = "unparsed";
+  @override
+  final String library = 'unparsed';
+  @override
   final String package = null;
-  final String location = "unparsed";
+  @override
+  final String location = 'unparsed';
 
+  @override
   final String member;
 
   UnparsedFrame(this.member);
 
+  @override
   String toString() => member;
 }

--- a/lib/src/vm_trace.dart
+++ b/lib/src/vm_trace.dart
@@ -15,17 +15,18 @@ class VMTrace implements StackTrace {
 
   VMTrace(this.frames);
 
+  @override
   String toString() {
     var i = 1;
     return frames.map((frame) {
-      var number = "#${i++}".padRight(8);
+      var number = '#${i++}'.padRight(8);
       var member = frame.member
-          .replaceAllMapped(RegExp(r"[^.]+\.<async>"),
-              (match) => "${match[1]}.<${match[1]}_async_body>")
-          .replaceAll("<fn>", "<anonymous closure>");
-      var line = frame.line == null ? 0 : frame.line;
-      var column = frame.column == null ? 0 : frame.column;
-      return "$number$member (${frame.uri}:$line:$column)\n";
+          .replaceAllMapped(RegExp(r'[^.]+\.<async>'),
+              (match) => '${match[1]}.<${match[1]}_async_body>')
+          .replaceAll('<fn>', '<anonymous closure>');
+      var line = frame.line ?? 0;
+      var column = frame.column ?? 0;
+      return '$number$member (${frame.uri}:$line:$column)\n';
     }).join();
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,4 +10,5 @@ dependencies:
   path: ^1.2.0
 
 dev_dependencies:
+  pedantic: ^1.9.0
   test: '>=0.12.17 <2.0.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,5 +10,5 @@ dependencies:
   path: ^1.2.0
 
 dev_dependencies:
-  pedantic: ^1.9.0
+  pedantic: ^1.0.0
   test: '>=0.12.17 <2.0.0'

--- a/test/chain/chain_test.dart
+++ b/test/chain/chain_test.dart
@@ -38,29 +38,29 @@ void main() {
     });
   });
 
-  group("Chain.capture()", () {
-    test("with onError blocks errors", () {
+  group('Chain.capture()', () {
+    test('with onError blocks errors', () {
       Chain.capture(() {
-        return Future.error("oh no");
+        return Future.error('oh no');
       }, onError: expectAsync2((error, chain) {
-        expect(error, equals("oh no"));
+        expect(error, equals('oh no'));
         expect(chain, TypeMatcher<Chain>());
       }));
     });
 
-    test("with no onError blocks errors", () {
+    test('with no onError blocks errors', () {
       runZoned(() {
-        var future = Chain.capture(() => Future.error("oh no"), when: false);
+        var future = Chain.capture(() => Future.error('oh no'), when: false);
         future.then(expectAsync1((_) {}, count: 0));
       }, onError: expectAsync2((error, chain) {
-        expect(error, equals("oh no"));
+        expect(error, equals('oh no'));
         expect(chain, TypeMatcher<Chain>());
       }));
     });
 
     test("with errorZone: false doesn't block errors", () {
-      expect(Chain.capture(() => Future.error("oh no"), errorZone: false),
-          throwsA("oh no"));
+      expect(Chain.capture(() => Future.error('oh no'), errorZone: false),
+          throwsA('oh no'));
     });
 
     test("doesn't allow onError and errorZone: false", () {
@@ -68,17 +68,17 @@ void main() {
           throwsArgumentError);
     });
 
-    group("with when: false", () {
+    group('with when: false', () {
       test("with no onError doesn't block errors", () {
-        expect(Chain.capture(() => Future.error("oh no"), when: false),
-            throwsA("oh no"));
+        expect(Chain.capture(() => Future.error('oh no'), when: false),
+            throwsA('oh no'));
       });
 
-      test("with onError blocks errors", () {
+      test('with onError blocks errors', () {
         Chain.capture(() {
-          return Future.error("oh no");
+          return Future.error('oh no');
         }, onError: expectAsync2((error, chain) {
-          expect(error, equals("oh no"));
+          expect(error, equals('oh no'));
           expect(chain, TypeMatcher<Chain>());
         }), when: false);
       });
@@ -100,8 +100,8 @@ void main() {
     });
   });
 
-  group("Chain.disable()", () {
-    test("disables chain-tracking", () {
+  group('Chain.disable()', () {
+    test('disables chain-tracking', () {
       return Chain.disable(() {
         var completer = Completer();
         inMicrotask(() => completer.complete(Chain.current()));
@@ -112,7 +112,7 @@ void main() {
       });
     });
 
-    test("Chain.capture() re-enables chain-tracking", () {
+    test('Chain.capture() re-enables chain-tracking', () {
       return Chain.disable(() {
         return Chain.capture(() {
           var completer = Completer();
@@ -125,7 +125,7 @@ void main() {
       });
     });
 
-    test("preserves parent zones of the capture zone", () {
+    test('preserves parent zones of the capture zone', () {
       // The outer disable call turns off the test package's chain-tracking.
       return Chain.disable(() {
         return runZoned(() {
@@ -136,7 +136,7 @@ void main() {
       });
     });
 
-    test("preserves child zones of the capture zone", () {
+    test('preserves child zones of the capture zone', () {
       // The outer disable call turns off the test package's chain-tracking.
       return Chain.disable(() {
         return Chain.capture(() {
@@ -161,7 +161,7 @@ void main() {
     });
   });
 
-  test("toString() ensures that all traces are aligned", () {
+  test('toString() ensures that all traces are aligned', () {
     var chain = Chain([
       Trace.parse('short 10:11  Foo.bar\n'),
       Trace.parse('loooooooooooong 10:11  Zop.zoop')

--- a/test/chain/utils.dart
+++ b/test/chain/utils.dart
@@ -8,13 +8,13 @@ import 'package:stack_trace/stack_trace.dart';
 import 'package:test/test.dart';
 
 /// Runs [callback] in a microtask callback.
-void inMicrotask(callback()) => scheduleMicrotask(callback);
+void inMicrotask(void Function() callback) => scheduleMicrotask(callback);
 
 /// Runs [callback] in a one-shot timer callback.
-void inOneShotTimer(callback()) => Timer.run(callback);
+void inOneShotTimer(void Function() callback) => Timer.run(callback);
 
 /// Runs [callback] once in a periodic timer callback.
-void inPeriodicTimer(callback()) {
+void inPeriodicTimer(void Function() callback) {
   var count = 0;
   Timer.periodic(Duration(milliseconds: 1), (timer) {
     count++;
@@ -25,7 +25,7 @@ void inPeriodicTimer(callback()) {
 }
 
 /// Runs [callback] within a long asynchronous Future chain.
-void inFutureChain(callback()) {
+void inFutureChain(void Function() callback) {
   Future(() {})
       .then((_) => Future(() {}))
       .then((_) => Future(() {}))
@@ -35,11 +35,11 @@ void inFutureChain(callback()) {
       .then((_) => Future(() {}));
 }
 
-void inNewFuture(callback()) {
+void inNewFuture(void Function() callback) {
   Future(callback);
 }
 
-void inSyncFuture(callback()) {
+void inSyncFuture(void Function() callback) {
   Future.sync(callback);
 }
 
@@ -63,7 +63,8 @@ Stream controllerErrorStream([StackTrace trace]) {
 
 /// Runs [callback] within [asyncFn], then converts any errors raised into a
 /// [Chain] with [Chain.forTrace].
-Future<Chain> chainForTrace(asyncFn(callback()), callback()) {
+Future<Chain> chainForTrace(
+    void Function(void Function()) asyncFn, void Function() callback) {
   var completer = Completer<Chain>();
   asyncFn(() {
     // We use `new Future.value().then(...)` here as opposed to [new Future] or
@@ -81,7 +82,7 @@ Future<Chain> chainForTrace(asyncFn(callback()), callback()) {
 /// completes to the stack chain for an error thrown by [callback].
 ///
 /// [callback] is expected to throw the string `"error"`.
-Future<Chain> captureFuture(callback()) {
+Future<Chain> captureFuture(void Function() callback) {
   var completer = Completer<Chain>();
   Chain.capture(callback, onError: (error, chain) {
     expect(error, equals('error'));

--- a/test/frame_test.dart
+++ b/test/frame_test.dart
@@ -9,20 +9,20 @@ import 'package:test/test.dart';
 void main() {
   group('.parseVM', () {
     test('parses a stack frame with column correctly', () {
-      var frame = Frame.parseVM("#1      Foo._bar "
-          "(file:///home/nweiz/code/stuff.dart:42:21)");
+      var frame = Frame.parseVM('#1      Foo._bar '
+          '(file:///home/nweiz/code/stuff.dart:42:21)');
       expect(
-          frame.uri, equals(Uri.parse("file:///home/nweiz/code/stuff.dart")));
+          frame.uri, equals(Uri.parse('file:///home/nweiz/code/stuff.dart')));
       expect(frame.line, equals(42));
       expect(frame.column, equals(21));
       expect(frame.member, equals('Foo._bar'));
     });
 
     test('parses a stack frame without column correctly', () {
-      var frame = Frame.parseVM("#1      Foo._bar "
-          "(file:///home/nweiz/code/stuff.dart:24)");
+      var frame = Frame.parseVM('#1      Foo._bar '
+          '(file:///home/nweiz/code/stuff.dart:24)');
       expect(
-          frame.uri, equals(Uri.parse("file:///home/nweiz/code/stuff.dart")));
+          frame.uri, equals(Uri.parse('file:///home/nweiz/code/stuff.dart')));
       expect(frame.line, equals(24));
       expect(frame.column, null);
       expect(frame.member, equals('Foo._bar'));
@@ -30,10 +30,10 @@ void main() {
 
     // This can happen with async stack traces. See issue 22009.
     test('parses a stack frame without line or column correctly', () {
-      var frame = Frame.parseVM("#1      Foo._bar "
-          "(file:///home/nweiz/code/stuff.dart)");
+      var frame = Frame.parseVM('#1      Foo._bar '
+          '(file:///home/nweiz/code/stuff.dart)');
       expect(
-          frame.uri, equals(Uri.parse("file:///home/nweiz/code/stuff.dart")));
+          frame.uri, equals(Uri.parse('file:///home/nweiz/code/stuff.dart')));
       expect(frame.line, isNull);
       expect(frame.column, isNull);
       expect(frame.member, equals('Foo._bar'));
@@ -81,56 +81,56 @@ void main() {
     });
 
     test('parses a stack frame correctly', () {
-      var frame = Frame.parseV8("    at VW.call\$0 "
-          "(http://pub.dartlang.org/stuff.dart.js:560:28)");
+      var frame = Frame.parseV8('    at VW.call\$0 '
+          '(http://pub.dartlang.org/stuff.dart.js:560:28)');
       expect(frame.uri,
-          equals(Uri.parse("http://pub.dartlang.org/stuff.dart.js")));
+          equals(Uri.parse('http://pub.dartlang.org/stuff.dart.js')));
       expect(frame.line, equals(560));
       expect(frame.column, equals(28));
       expect(frame.member, equals('VW.call\$0'));
     });
 
     test('parses a stack frame with an absolute POSIX path correctly', () {
-      var frame = Frame.parseV8("    at VW.call\$0 "
-          "(/path/to/stuff.dart.js:560:28)");
-      expect(frame.uri, equals(Uri.parse("file:///path/to/stuff.dart.js")));
+      var frame = Frame.parseV8('    at VW.call\$0 '
+          '(/path/to/stuff.dart.js:560:28)');
+      expect(frame.uri, equals(Uri.parse('file:///path/to/stuff.dart.js')));
       expect(frame.line, equals(560));
       expect(frame.column, equals(28));
       expect(frame.member, equals('VW.call\$0'));
     });
 
     test('parses a stack frame with an absolute Windows path correctly', () {
-      var frame = Frame.parseV8("    at VW.call\$0 "
-          r"(C:\path\to\stuff.dart.js:560:28)");
-      expect(frame.uri, equals(Uri.parse("file:///C:/path/to/stuff.dart.js")));
+      var frame = Frame.parseV8('    at VW.call\$0 '
+          r'(C:\path\to\stuff.dart.js:560:28)');
+      expect(frame.uri, equals(Uri.parse('file:///C:/path/to/stuff.dart.js')));
       expect(frame.line, equals(560));
       expect(frame.column, equals(28));
       expect(frame.member, equals('VW.call\$0'));
     });
 
     test('parses a stack frame with a Windows UNC path correctly', () {
-      var frame = Frame.parseV8("    at VW.call\$0 "
-          r"(\\mount\path\to\stuff.dart.js:560:28)");
+      var frame = Frame.parseV8('    at VW.call\$0 '
+          r'(\\mount\path\to\stuff.dart.js:560:28)');
       expect(
-          frame.uri, equals(Uri.parse("file://mount/path/to/stuff.dart.js")));
+          frame.uri, equals(Uri.parse('file://mount/path/to/stuff.dart.js')));
       expect(frame.line, equals(560));
       expect(frame.column, equals(28));
       expect(frame.member, equals('VW.call\$0'));
     });
 
     test('parses a stack frame with a relative POSIX path correctly', () {
-      var frame = Frame.parseV8("    at VW.call\$0 "
-          "(path/to/stuff.dart.js:560:28)");
-      expect(frame.uri, equals(Uri.parse("path/to/stuff.dart.js")));
+      var frame = Frame.parseV8('    at VW.call\$0 '
+          '(path/to/stuff.dart.js:560:28)');
+      expect(frame.uri, equals(Uri.parse('path/to/stuff.dart.js')));
       expect(frame.line, equals(560));
       expect(frame.column, equals(28));
       expect(frame.member, equals('VW.call\$0'));
     });
 
     test('parses a stack frame with a relative Windows path correctly', () {
-      var frame = Frame.parseV8("    at VW.call\$0 "
-          r"(path\to\stuff.dart.js:560:28)");
-      expect(frame.uri, equals(Uri.parse("path/to/stuff.dart.js")));
+      var frame = Frame.parseV8('    at VW.call\$0 '
+          r'(path\to\stuff.dart.js:560:28)');
+      expect(frame.uri, equals(Uri.parse('path/to/stuff.dart.js')));
       expect(frame.line, equals(560));
       expect(frame.column, equals(28));
       expect(frame.member, equals('VW.call\$0'));
@@ -138,16 +138,16 @@ void main() {
 
     test('parses an anonymous stack frame correctly', () {
       var frame =
-          Frame.parseV8("    at http://pub.dartlang.org/stuff.dart.js:560:28");
+          Frame.parseV8('    at http://pub.dartlang.org/stuff.dart.js:560:28');
       expect(frame.uri,
-          equals(Uri.parse("http://pub.dartlang.org/stuff.dart.js")));
+          equals(Uri.parse('http://pub.dartlang.org/stuff.dart.js')));
       expect(frame.line, equals(560));
       expect(frame.column, equals(28));
       expect(frame.member, equals('<fn>'));
     });
 
     test('parses a native stack frame correctly', () {
-      var frame = Frame.parseV8("    at Object.stringify (native)");
+      var frame = Frame.parseV8('    at Object.stringify (native)');
       expect(frame.uri, Uri.parse('native'));
       expect(frame.line, isNull);
       expect(frame.column, isNull);
@@ -157,50 +157,50 @@ void main() {
     test('parses a stack frame with [as ...] correctly', () {
       // Ignore "[as ...]", since other stack trace formats don't support a
       // similar construct.
-      var frame = Frame.parseV8("    at VW.call\$0 [as call\$4] "
-          "(http://pub.dartlang.org/stuff.dart.js:560:28)");
+      var frame = Frame.parseV8('    at VW.call\$0 [as call\$4] '
+          '(http://pub.dartlang.org/stuff.dart.js:560:28)');
       expect(frame.uri,
-          equals(Uri.parse("http://pub.dartlang.org/stuff.dart.js")));
+          equals(Uri.parse('http://pub.dartlang.org/stuff.dart.js')));
       expect(frame.line, equals(560));
       expect(frame.column, equals(28));
       expect(frame.member, equals('VW.call\$0'));
     });
 
     test('parses a basic eval stack frame correctly', () {
-      var frame = Frame.parseV8("    at eval (eval at <anonymous> "
-          "(http://pub.dartlang.org/stuff.dart.js:560:28))");
+      var frame = Frame.parseV8('    at eval (eval at <anonymous> '
+          '(http://pub.dartlang.org/stuff.dart.js:560:28))');
       expect(frame.uri,
-          equals(Uri.parse("http://pub.dartlang.org/stuff.dart.js")));
+          equals(Uri.parse('http://pub.dartlang.org/stuff.dart.js')));
       expect(frame.line, equals(560));
       expect(frame.column, equals(28));
       expect(frame.member, equals('eval'));
     });
 
     test('parses an IE10 eval stack frame correctly', () {
-      var frame = Frame.parseV8("    at eval (eval at Anonymous function "
-          "(http://pub.dartlang.org/stuff.dart.js:560:28))");
+      var frame = Frame.parseV8('    at eval (eval at Anonymous function '
+          '(http://pub.dartlang.org/stuff.dart.js:560:28))');
       expect(frame.uri,
-          equals(Uri.parse("http://pub.dartlang.org/stuff.dart.js")));
+          equals(Uri.parse('http://pub.dartlang.org/stuff.dart.js')));
       expect(frame.line, equals(560));
       expect(frame.column, equals(28));
       expect(frame.member, equals('eval'));
     });
 
     test('parses an eval stack frame with inner position info correctly', () {
-      var frame = Frame.parseV8("    at eval (eval at <anonymous> "
-          "(http://pub.dartlang.org/stuff.dart.js:560:28), <anonymous>:3:28)");
+      var frame = Frame.parseV8('    at eval (eval at <anonymous> '
+          '(http://pub.dartlang.org/stuff.dart.js:560:28), <anonymous>:3:28)');
       expect(frame.uri,
-          equals(Uri.parse("http://pub.dartlang.org/stuff.dart.js")));
+          equals(Uri.parse('http://pub.dartlang.org/stuff.dart.js')));
       expect(frame.line, equals(560));
       expect(frame.column, equals(28));
       expect(frame.member, equals('eval'));
     });
 
     test('parses a nested eval stack frame correctly', () {
-      var frame = Frame.parseV8("    at eval (eval at <anonymous> "
-          "(eval at sub (http://pub.dartlang.org/stuff.dart.js:560:28)))");
+      var frame = Frame.parseV8('    at eval (eval at <anonymous> '
+          '(eval at sub (http://pub.dartlang.org/stuff.dart.js:560:28)))');
       expect(frame.uri,
-          equals(Uri.parse("http://pub.dartlang.org/stuff.dart.js")));
+          equals(Uri.parse('http://pub.dartlang.org/stuff.dart.js')));
       expect(frame.line, equals(560));
       expect(frame.column, equals(28));
       expect(frame.member, equals('eval'));
@@ -242,20 +242,20 @@ anonymous/<@http://pub.dartlang.org/stuff.js line 693 > Function:3:40
 baz@http://pub.dartlang.org/buz.js:56355:55
         ''');
       expect(trace.frames[0].uri,
-          equals(Uri.parse("http://pub.dartlang.org/stuff.js")));
+          equals(Uri.parse('http://pub.dartlang.org/stuff.js')));
       expect(trace.frames[0].line, equals(18056));
       expect(trace.frames[0].column, equals(12));
-      expect(trace.frames[0].member, equals("Foo._bar"));
+      expect(trace.frames[0].member, equals('Foo._bar'));
       expect(trace.frames[1].uri,
-          equals(Uri.parse("http://pub.dartlang.org/stuff.js")));
+          equals(Uri.parse('http://pub.dartlang.org/stuff.js')));
       expect(trace.frames[1].line, equals(693));
       expect(trace.frames[1].column, isNull);
-      expect(trace.frames[1].member, equals("<fn>"));
+      expect(trace.frames[1].member, equals('<fn>'));
       expect(trace.frames[2].uri,
-          equals(Uri.parse("http://pub.dartlang.org/buz.js")));
+          equals(Uri.parse('http://pub.dartlang.org/buz.js')));
       expect(trace.frames[2].line, equals(56355));
       expect(trace.frames[2].column, equals(55));
-      expect(trace.frames[2].member, equals("baz"));
+      expect(trace.frames[2].member, equals('baz'));
     });
 
     test('parses a Firefox stack trace with nested evals in anonymous function',
@@ -266,33 +266,33 @@ baz@http://pub.dartlang.org/buz.js:56355:55
         anonymous@file:///C:/example.html line 45 > Function:1:1
         ''');
       expect(trace.frames[0].uri,
-          equals(Uri.parse("http://pub.dartlang.org/stuff.js")));
+          equals(Uri.parse('http://pub.dartlang.org/stuff.js')));
       expect(trace.frames[0].line, equals(18056));
       expect(trace.frames[0].column, equals(12));
-      expect(trace.frames[0].member, equals("Foo._bar"));
-      expect(trace.frames[1].uri, equals(Uri.parse("file:///C:/example.html")));
+      expect(trace.frames[0].member, equals('Foo._bar'));
+      expect(trace.frames[1].uri, equals(Uri.parse('file:///C:/example.html')));
       expect(trace.frames[1].line, equals(7));
       expect(trace.frames[1].column, isNull);
-      expect(trace.frames[1].member, equals("<fn>"));
-      expect(trace.frames[2].uri, equals(Uri.parse("file:///C:/example.html")));
+      expect(trace.frames[1].member, equals('<fn>'));
+      expect(trace.frames[2].uri, equals(Uri.parse('file:///C:/example.html')));
       expect(trace.frames[2].line, equals(45));
       expect(trace.frames[2].column, isNull);
-      expect(trace.frames[2].member, equals("<fn>"));
+      expect(trace.frames[2].member, equals('<fn>'));
     });
 
     test('parses a simple stack frame correctly', () {
       var frame = Frame.parseFirefox(
-          ".VW.call\$0@http://pub.dartlang.org/stuff.dart.js:560");
+          '.VW.call\$0@http://pub.dartlang.org/stuff.dart.js:560');
       expect(frame.uri,
-          equals(Uri.parse("http://pub.dartlang.org/stuff.dart.js")));
+          equals(Uri.parse('http://pub.dartlang.org/stuff.dart.js')));
       expect(frame.line, equals(560));
       expect(frame.column, isNull);
       expect(frame.member, equals('VW.call\$0'));
     });
 
     test('parses a stack frame with an absolute POSIX path correctly', () {
-      var frame = Frame.parseFirefox(".VW.call\$0@/path/to/stuff.dart.js:560");
-      expect(frame.uri, equals(Uri.parse("file:///path/to/stuff.dart.js")));
+      var frame = Frame.parseFirefox('.VW.call\$0@/path/to/stuff.dart.js:560');
+      expect(frame.uri, equals(Uri.parse('file:///path/to/stuff.dart.js')));
       expect(frame.line, equals(560));
       expect(frame.column, isNull);
       expect(frame.member, equals('VW.call\$0'));
@@ -300,8 +300,8 @@ baz@http://pub.dartlang.org/buz.js:56355:55
 
     test('parses a stack frame with an absolute Windows path correctly', () {
       var frame =
-          Frame.parseFirefox(r".VW.call$0@C:\path\to\stuff.dart.js:560");
-      expect(frame.uri, equals(Uri.parse("file:///C:/path/to/stuff.dart.js")));
+          Frame.parseFirefox(r'.VW.call$0@C:\path\to\stuff.dart.js:560');
+      expect(frame.uri, equals(Uri.parse('file:///C:/path/to/stuff.dart.js')));
       expect(frame.line, equals(560));
       expect(frame.column, isNull);
       expect(frame.member, equals('VW.call\$0'));
@@ -309,25 +309,25 @@ baz@http://pub.dartlang.org/buz.js:56355:55
 
     test('parses a stack frame with a Windows UNC path correctly', () {
       var frame =
-          Frame.parseFirefox(r".VW.call$0@\\mount\path\to\stuff.dart.js:560");
+          Frame.parseFirefox(r'.VW.call$0@\\mount\path\to\stuff.dart.js:560');
       expect(
-          frame.uri, equals(Uri.parse("file://mount/path/to/stuff.dart.js")));
+          frame.uri, equals(Uri.parse('file://mount/path/to/stuff.dart.js')));
       expect(frame.line, equals(560));
       expect(frame.column, isNull);
       expect(frame.member, equals('VW.call\$0'));
     });
 
     test('parses a stack frame with a relative POSIX path correctly', () {
-      var frame = Frame.parseFirefox(".VW.call\$0@path/to/stuff.dart.js:560");
-      expect(frame.uri, equals(Uri.parse("path/to/stuff.dart.js")));
+      var frame = Frame.parseFirefox('.VW.call\$0@path/to/stuff.dart.js:560');
+      expect(frame.uri, equals(Uri.parse('path/to/stuff.dart.js')));
       expect(frame.line, equals(560));
       expect(frame.column, isNull);
       expect(frame.member, equals('VW.call\$0'));
     });
 
     test('parses a stack frame with a relative Windows path correctly', () {
-      var frame = Frame.parseFirefox(r".VW.call$0@path\to\stuff.dart.js:560");
-      expect(frame.uri, equals(Uri.parse("path/to/stuff.dart.js")));
+      var frame = Frame.parseFirefox(r'.VW.call$0@path\to\stuff.dart.js:560');
+      expect(frame.uri, equals(Uri.parse('path/to/stuff.dart.js')));
       expect(frame.line, equals(560));
       expect(frame.column, isNull);
       expect(frame.member, equals('VW.call\$0'));
@@ -335,68 +335,68 @@ baz@http://pub.dartlang.org/buz.js:56355:55
 
     test('parses a simple anonymous stack frame correctly', () {
       var frame =
-          Frame.parseFirefox("@http://pub.dartlang.org/stuff.dart.js:560");
+          Frame.parseFirefox('@http://pub.dartlang.org/stuff.dart.js:560');
       expect(frame.uri,
-          equals(Uri.parse("http://pub.dartlang.org/stuff.dart.js")));
+          equals(Uri.parse('http://pub.dartlang.org/stuff.dart.js')));
       expect(frame.line, equals(560));
       expect(frame.column, isNull);
-      expect(frame.member, equals("<fn>"));
+      expect(frame.member, equals('<fn>'));
     });
 
     test('parses a nested anonymous stack frame correctly', () {
       var frame = Frame.parseFirefox(
-          ".foo/<@http://pub.dartlang.org/stuff.dart.js:560");
+          '.foo/<@http://pub.dartlang.org/stuff.dart.js:560');
       expect(frame.uri,
-          equals(Uri.parse("http://pub.dartlang.org/stuff.dart.js")));
+          equals(Uri.parse('http://pub.dartlang.org/stuff.dart.js')));
       expect(frame.line, equals(560));
       expect(frame.column, isNull);
-      expect(frame.member, equals("foo.<fn>"));
+      expect(frame.member, equals('foo.<fn>'));
 
       frame =
-          Frame.parseFirefox(".foo/@http://pub.dartlang.org/stuff.dart.js:560");
+          Frame.parseFirefox('.foo/@http://pub.dartlang.org/stuff.dart.js:560');
       expect(frame.uri,
-          equals(Uri.parse("http://pub.dartlang.org/stuff.dart.js")));
+          equals(Uri.parse('http://pub.dartlang.org/stuff.dart.js')));
       expect(frame.line, equals(560));
       expect(frame.column, isNull);
-      expect(frame.member, equals("foo.<fn>"));
+      expect(frame.member, equals('foo.<fn>'));
     });
 
     test('parses a named nested anonymous stack frame correctly', () {
       var frame = Frame.parseFirefox(
-          ".foo/.name<@http://pub.dartlang.org/stuff.dart.js:560");
+          '.foo/.name<@http://pub.dartlang.org/stuff.dart.js:560');
       expect(frame.uri,
-          equals(Uri.parse("http://pub.dartlang.org/stuff.dart.js")));
+          equals(Uri.parse('http://pub.dartlang.org/stuff.dart.js')));
       expect(frame.line, equals(560));
       expect(frame.column, isNull);
-      expect(frame.member, equals("foo.<fn>"));
+      expect(frame.member, equals('foo.<fn>'));
 
       frame = Frame.parseFirefox(
-          ".foo/.name@http://pub.dartlang.org/stuff.dart.js:560");
+          '.foo/.name@http://pub.dartlang.org/stuff.dart.js:560');
       expect(frame.uri,
-          equals(Uri.parse("http://pub.dartlang.org/stuff.dart.js")));
+          equals(Uri.parse('http://pub.dartlang.org/stuff.dart.js')));
       expect(frame.line, equals(560));
       expect(frame.column, isNull);
-      expect(frame.member, equals("foo.<fn>"));
+      expect(frame.member, equals('foo.<fn>'));
     });
 
     test('parses a stack frame with parameters correctly', () {
       var frame = Frame.parseFirefox(
           '.foo(12, "@)()/<")@http://pub.dartlang.org/stuff.dart.js:560');
       expect(frame.uri,
-          equals(Uri.parse("http://pub.dartlang.org/stuff.dart.js")));
+          equals(Uri.parse('http://pub.dartlang.org/stuff.dart.js')));
       expect(frame.line, equals(560));
       expect(frame.column, isNull);
-      expect(frame.member, equals("foo"));
+      expect(frame.member, equals('foo'));
     });
 
     test('parses a nested anonymous stack frame with parameters correctly', () {
       var frame = Frame.parseFirefox('.foo(12, "@)()/<")/.fn<@'
           'http://pub.dartlang.org/stuff.dart.js:560');
       expect(frame.uri,
-          equals(Uri.parse("http://pub.dartlang.org/stuff.dart.js")));
+          equals(Uri.parse('http://pub.dartlang.org/stuff.dart.js')));
       expect(frame.line, equals(560));
       expect(frame.column, isNull);
-      expect(frame.member, equals("foo.<fn>"));
+      expect(frame.member, equals('foo.<fn>'));
     });
 
     test(
@@ -405,10 +405,10 @@ baz@http://pub.dartlang.org/buz.js:56355:55
       var frame = Frame.parseFirefox('.convertDartClosureToJS/\$function</<@'
           'http://pub.dartlang.org/stuff.dart.js:560');
       expect(frame.uri,
-          equals(Uri.parse("http://pub.dartlang.org/stuff.dart.js")));
+          equals(Uri.parse('http://pub.dartlang.org/stuff.dart.js')));
       expect(frame.line, equals(560));
       expect(frame.column, isNull);
-      expect(frame.member, equals("convertDartClosureToJS.<fn>.<fn>"));
+      expect(frame.member, equals('convertDartClosureToJS.<fn>.<fn>'));
     });
 
     test('returns an UnparsedFrame for malformed frames', () {
@@ -424,16 +424,16 @@ baz@http://pub.dartlang.org/buz.js:56355:55
 
     test('parses a simple stack frame correctly', () {
       var frame =
-          Frame.parseFirefox("foo\$bar@http://dartlang.org/foo/bar.dart:10:11");
-      expect(frame.uri, equals(Uri.parse("http://dartlang.org/foo/bar.dart")));
+          Frame.parseFirefox('foo\$bar@http://dartlang.org/foo/bar.dart:10:11');
+      expect(frame.uri, equals(Uri.parse('http://dartlang.org/foo/bar.dart')));
       expect(frame.line, equals(10));
       expect(frame.column, equals(11));
       expect(frame.member, equals('foo\$bar'));
     });
 
     test('parses an anonymous stack frame correctly', () {
-      var frame = Frame.parseFirefox("http://dartlang.org/foo/bar.dart:10:11");
-      expect(frame.uri, equals(Uri.parse("http://dartlang.org/foo/bar.dart")));
+      var frame = Frame.parseFirefox('http://dartlang.org/foo/bar.dart:10:11');
+      expect(frame.uri, equals(Uri.parse('http://dartlang.org/foo/bar.dart')));
       expect(frame.line, equals(10));
       expect(frame.column, equals(11));
       expect(frame.member, equals('<fn>'));
@@ -441,8 +441,8 @@ baz@http://pub.dartlang.org/buz.js:56355:55
 
     test('parses a stack frame with no line correctly', () {
       var frame =
-          Frame.parseFirefox("foo\$bar@http://dartlang.org/foo/bar.dart::11");
-      expect(frame.uri, equals(Uri.parse("http://dartlang.org/foo/bar.dart")));
+          Frame.parseFirefox('foo\$bar@http://dartlang.org/foo/bar.dart::11');
+      expect(frame.uri, equals(Uri.parse('http://dartlang.org/foo/bar.dart')));
       expect(frame.line, isNull);
       expect(frame.column, equals(11));
       expect(frame.member, equals('foo\$bar'));
@@ -450,8 +450,8 @@ baz@http://pub.dartlang.org/buz.js:56355:55
 
     test('parses a stack frame with no column correctly', () {
       var frame =
-          Frame.parseFirefox("foo\$bar@http://dartlang.org/foo/bar.dart:10:");
-      expect(frame.uri, equals(Uri.parse("http://dartlang.org/foo/bar.dart")));
+          Frame.parseFirefox('foo\$bar@http://dartlang.org/foo/bar.dart:10:');
+      expect(frame.uri, equals(Uri.parse('http://dartlang.org/foo/bar.dart')));
       expect(frame.line, equals(10));
       expect(frame.column, isNull);
       expect(frame.member, equals('foo\$bar'));
@@ -459,8 +459,8 @@ baz@http://pub.dartlang.org/buz.js:56355:55
 
     test('parses a stack frame with no line or column correctly', () {
       var frame =
-          Frame.parseFirefox("foo\$bar@http://dartlang.org/foo/bar.dart:10:11");
-      expect(frame.uri, equals(Uri.parse("http://dartlang.org/foo/bar.dart")));
+          Frame.parseFirefox('foo\$bar@http://dartlang.org/foo/bar.dart:10:11');
+      expect(frame.uri, equals(Uri.parse('http://dartlang.org/foo/bar.dart')));
       expect(frame.line, equals(10));
       expect(frame.column, equals(11));
       expect(frame.member, equals('foo\$bar'));
@@ -470,8 +470,8 @@ baz@http://pub.dartlang.org/buz.js:56355:55
   group('.parseFriendly', () {
     test('parses a simple stack frame correctly', () {
       var frame = Frame.parseFriendly(
-          "http://dartlang.org/foo/bar.dart 10:11  Foo.<fn>.bar");
-      expect(frame.uri, equals(Uri.parse("http://dartlang.org/foo/bar.dart")));
+          'http://dartlang.org/foo/bar.dart 10:11  Foo.<fn>.bar');
+      expect(frame.uri, equals(Uri.parse('http://dartlang.org/foo/bar.dart')));
       expect(frame.line, equals(10));
       expect(frame.column, equals(11));
       expect(frame.member, equals('Foo.<fn>.bar'));
@@ -479,8 +479,8 @@ baz@http://pub.dartlang.org/buz.js:56355:55
 
     test('parses a stack frame with no line or column correctly', () {
       var frame =
-          Frame.parseFriendly("http://dartlang.org/foo/bar.dart  Foo.<fn>.bar");
-      expect(frame.uri, equals(Uri.parse("http://dartlang.org/foo/bar.dart")));
+          Frame.parseFriendly('http://dartlang.org/foo/bar.dart  Foo.<fn>.bar');
+      expect(frame.uri, equals(Uri.parse('http://dartlang.org/foo/bar.dart')));
       expect(frame.line, isNull);
       expect(frame.column, isNull);
       expect(frame.member, equals('Foo.<fn>.bar'));
@@ -488,15 +488,15 @@ baz@http://pub.dartlang.org/buz.js:56355:55
 
     test('parses a stack frame with no column correctly', () {
       var frame = Frame.parseFriendly(
-          "http://dartlang.org/foo/bar.dart 10  Foo.<fn>.bar");
-      expect(frame.uri, equals(Uri.parse("http://dartlang.org/foo/bar.dart")));
+          'http://dartlang.org/foo/bar.dart 10  Foo.<fn>.bar');
+      expect(frame.uri, equals(Uri.parse('http://dartlang.org/foo/bar.dart')));
       expect(frame.line, equals(10));
       expect(frame.column, isNull);
       expect(frame.member, equals('Foo.<fn>.bar'));
     });
 
     test('parses a stack frame with a relative path correctly', () {
-      var frame = Frame.parseFriendly("foo/bar.dart 10:11    Foo.<fn>.bar");
+      var frame = Frame.parseFriendly('foo/bar.dart 10:11    Foo.<fn>.bar');
       expect(frame.uri,
           equals(path.toUri(path.absolute(path.join('foo', 'bar.dart')))));
       expect(frame.line, equals(10));
@@ -512,7 +512,7 @@ baz@http://pub.dartlang.org/buz.js:56355:55
     });
 
     test('parses a data url stack frame with no line or column correctly', () {
-      var frame = Frame.parseFriendly("data:...  main");
+      var frame = Frame.parseFriendly('data:...  main');
       expect(frame.uri.scheme, equals('data'));
       expect(frame.line, isNull);
       expect(frame.column, isNull);
@@ -520,7 +520,7 @@ baz@http://pub.dartlang.org/buz.js:56355:55
     });
 
     test('parses a data url stack frame correctly', () {
-      var frame = Frame.parseFriendly("data:... 10:11    main");
+      var frame = Frame.parseFriendly('data:... 10:11    main');
       expect(frame.uri.scheme, equals('data'));
       expect(frame.line, equals(10));
       expect(frame.column, equals(11));
@@ -529,7 +529,7 @@ baz@http://pub.dartlang.org/buz.js:56355:55
 
     test('parses a stack frame with spaces in the member name correctly', () {
       var frame = Frame.parseFriendly(
-          "foo/bar.dart 10:11    (anonymous function).dart.fn");
+          'foo/bar.dart 10:11    (anonymous function).dart.fn');
       expect(frame.uri,
           equals(path.toUri(path.absolute(path.join('foo', 'bar.dart')))));
       expect(frame.line, equals(10));
@@ -541,8 +541,8 @@ baz@http://pub.dartlang.org/buz.js:56355:55
         'parses a stack frame with spaces in the member name and no line or '
         'column correctly', () {
       var frame = Frame.parseFriendly(
-          "http://dartlang.org/foo/bar.dart  (anonymous function).dart.fn");
-      expect(frame.uri, equals(Uri.parse("http://dartlang.org/foo/bar.dart")));
+          'http://dartlang.org/foo/bar.dart  (anonymous function).dart.fn');
+      expect(frame.uri, equals(Uri.parse('http://dartlang.org/foo/bar.dart')));
       expect(frame.line, isNull);
       expect(frame.column, isNull);
       expect(frame.member, equals('(anonymous function).dart.fn'));
@@ -650,7 +650,7 @@ baz@http://pub.dartlang.org/buz.js:56355:55
   });
 }
 
-void expectIsUnparsed(Frame constructor(String text), String text) {
+void expectIsUnparsed(Frame Function(String) constructor, String text) {
   var frame = constructor(text);
   expect(frame, TypeMatcher<UnparsedFrame>());
   expect(frame.toString(), equals(text));

--- a/test/trace_test.dart
+++ b/test/trace_test.dart
@@ -347,7 +347,7 @@ dart:core  bottom
       });
     });
 
-    group(".foldFrames", () {
+    group('.foldFrames', () {
       test('folds frames together bottom-up', () {
         var trace = Trace.parse('''
 #0 notFoo (foo.dart:42:21)
@@ -382,7 +382,7 @@ dart:async-patch/future.dart 9:11  fooBottom
 '''));
       });
 
-      group("with terse: true", () {
+      group('with terse: true', () {
         test('folds core frames as well', () {
           var trace = Trace.parse('''
 #0 notFoo (foo.dart:42:21)

--- a/test/trace_test.dart
+++ b/test/trace_test.dart
@@ -23,10 +23,10 @@ void main() {
           'dart:1:100)');
 
       expect(trace.frames[0].uri,
-          equals(Uri.parse("file:///home/nweiz/code/stuff.dart")));
-      expect(trace.frames[1].uri, equals(Uri.parse("dart:async/future.dart")));
+          equals(Uri.parse('file:///home/nweiz/code/stuff.dart')));
+      expect(trace.frames[1].uri, equals(Uri.parse('dart:async/future.dart')));
       expect(trace.frames[2].uri,
-          equals(Uri.parse("http://pub.dartlang.org/thing.dart")));
+          equals(Uri.parse('http://pub.dartlang.org/thing.dart')));
     });
 
     test('parses a V8 stack trace correctly', () {
@@ -37,24 +37,24 @@ void main() {
           '(http://pub.dartlang.org/thing.js:1:100)');
 
       expect(trace.frames[0].uri,
-          equals(Uri.parse("http://pub.dartlang.org/stuff.js")));
+          equals(Uri.parse('http://pub.dartlang.org/stuff.js')));
       expect(trace.frames[1].uri,
-          equals(Uri.parse("http://pub.dartlang.org/stuff.js")));
+          equals(Uri.parse('http://pub.dartlang.org/stuff.js')));
       expect(trace.frames[2].uri,
-          equals(Uri.parse("http://pub.dartlang.org/thing.js")));
+          equals(Uri.parse('http://pub.dartlang.org/thing.js')));
 
-      trace = Trace.parse("Exception: foo\n"
+      trace = Trace.parse('Exception: foo\n'
           '    at Foo._bar (http://pub.dartlang.org/stuff.js:42:21)\n'
           '    at http://pub.dartlang.org/stuff.js:0:2\n'
           '    at zip.<anonymous>.zap '
           '(http://pub.dartlang.org/thing.js:1:100)');
 
       expect(trace.frames[0].uri,
-          equals(Uri.parse("http://pub.dartlang.org/stuff.js")));
+          equals(Uri.parse('http://pub.dartlang.org/stuff.js')));
       expect(trace.frames[1].uri,
-          equals(Uri.parse("http://pub.dartlang.org/stuff.js")));
+          equals(Uri.parse('http://pub.dartlang.org/stuff.js')));
       expect(trace.frames[2].uri,
-          equals(Uri.parse("http://pub.dartlang.org/thing.js")));
+          equals(Uri.parse('http://pub.dartlang.org/thing.js')));
 
       trace = Trace.parse('Exception: foo\n'
           '    bar\n'
@@ -64,11 +64,11 @@ void main() {
           '(http://pub.dartlang.org/thing.js:1:100)');
 
       expect(trace.frames[0].uri,
-          equals(Uri.parse("http://pub.dartlang.org/stuff.js")));
+          equals(Uri.parse('http://pub.dartlang.org/stuff.js')));
       expect(trace.frames[1].uri,
-          equals(Uri.parse("http://pub.dartlang.org/stuff.js")));
+          equals(Uri.parse('http://pub.dartlang.org/stuff.js')));
       expect(trace.frames[2].uri,
-          equals(Uri.parse("http://pub.dartlang.org/thing.js")));
+          equals(Uri.parse('http://pub.dartlang.org/thing.js')));
 
       trace = Trace.parse('Exception: foo\n'
           '    bar\n'
@@ -78,13 +78,13 @@ void main() {
           '(http://pub.dartlang.org/thing.js:1:100)');
 
       expect(trace.frames[0].uri,
-          equals(Uri.parse("http://pub.dartlang.org/stuff.js")));
+          equals(Uri.parse('http://pub.dartlang.org/stuff.js')));
       expect(trace.frames[1].uri,
-          equals(Uri.parse("http://pub.dartlang.org/stuff.js")));
-      expect(trace.frames[1].member, equals("<fn>"));
+          equals(Uri.parse('http://pub.dartlang.org/stuff.js')));
+      expect(trace.frames[1].member, equals('<fn>'));
       expect(trace.frames[2].uri,
-          equals(Uri.parse("http://pub.dartlang.org/thing.js")));
-      expect(trace.frames[2].member, equals("<fn>.zip.zap"));
+          equals(Uri.parse('http://pub.dartlang.org/thing.js')));
+      expect(trace.frames[2].member, equals('<fn>.zip.zap'));
     });
 
     // JavaScriptCore traces are just like V8, except that it doesn't have a
@@ -97,11 +97,11 @@ void main() {
               '(http://pub.dartlang.org/thing.js:1:100)');
 
       expect(trace.frames[0].uri,
-          equals(Uri.parse("http://pub.dartlang.org/stuff.js")));
+          equals(Uri.parse('http://pub.dartlang.org/stuff.js')));
       expect(trace.frames[1].uri,
-          equals(Uri.parse("http://pub.dartlang.org/stuff.js")));
+          equals(Uri.parse('http://pub.dartlang.org/stuff.js')));
       expect(trace.frames[2].uri,
-          equals(Uri.parse("http://pub.dartlang.org/thing.js")));
+          equals(Uri.parse('http://pub.dartlang.org/thing.js')));
 
       trace =
           Trace.parse('\tat Foo._bar (http://pub.dartlang.org/stuff.js:42:21)\n'
@@ -110,9 +110,9 @@ void main() {
               '(http://pub.dartlang.org/thing.js:1:100)');
 
       expect(trace.frames[0].uri,
-          equals(Uri.parse("http://pub.dartlang.org/stuff.js")));
+          equals(Uri.parse('http://pub.dartlang.org/stuff.js')));
       expect(trace.frames[1].uri,
-          equals(Uri.parse("http://pub.dartlang.org/thing.js")));
+          equals(Uri.parse('http://pub.dartlang.org/thing.js')));
     });
 
     test('parses a Firefox/Safari stack trace correctly', () {
@@ -121,22 +121,22 @@ void main() {
           'zip.zap(12, "@)()/<")@http://pub.dartlang.org/thing.js:1');
 
       expect(trace.frames[0].uri,
-          equals(Uri.parse("http://pub.dartlang.org/stuff.js")));
+          equals(Uri.parse('http://pub.dartlang.org/stuff.js')));
       expect(trace.frames[1].uri,
-          equals(Uri.parse("http://pub.dartlang.org/stuff.js")));
+          equals(Uri.parse('http://pub.dartlang.org/stuff.js')));
       expect(trace.frames[2].uri,
-          equals(Uri.parse("http://pub.dartlang.org/thing.js")));
+          equals(Uri.parse('http://pub.dartlang.org/thing.js')));
 
       trace = Trace.parse('zip/<@http://pub.dartlang.org/stuff.js:0\n'
           'Foo._bar@http://pub.dartlang.org/stuff.js:42\n'
           'zip.zap(12, "@)()/<")@http://pub.dartlang.org/thing.js:1');
 
       expect(trace.frames[0].uri,
-          equals(Uri.parse("http://pub.dartlang.org/stuff.js")));
+          equals(Uri.parse('http://pub.dartlang.org/stuff.js')));
       expect(trace.frames[1].uri,
-          equals(Uri.parse("http://pub.dartlang.org/stuff.js")));
+          equals(Uri.parse('http://pub.dartlang.org/stuff.js')));
       expect(trace.frames[2].uri,
-          equals(Uri.parse("http://pub.dartlang.org/thing.js")));
+          equals(Uri.parse('http://pub.dartlang.org/thing.js')));
 
       trace = Trace.parse(
           'zip.zap(12, "@)()/<")@http://pub.dartlang.org/thing.js:1\n'
@@ -144,11 +144,11 @@ void main() {
           'Foo._bar@http://pub.dartlang.org/stuff.js:42');
 
       expect(trace.frames[0].uri,
-          equals(Uri.parse("http://pub.dartlang.org/thing.js")));
+          equals(Uri.parse('http://pub.dartlang.org/thing.js')));
       expect(trace.frames[1].uri,
-          equals(Uri.parse("http://pub.dartlang.org/stuff.js")));
+          equals(Uri.parse('http://pub.dartlang.org/stuff.js')));
       expect(trace.frames[2].uri,
-          equals(Uri.parse("http://pub.dartlang.org/stuff.js")));
+          equals(Uri.parse('http://pub.dartlang.org/stuff.js')));
     });
 
     test('parses a Firefox/Safari stack trace containing native code correctly',
@@ -159,11 +159,11 @@ void main() {
           '[native code]');
 
       expect(trace.frames[0].uri,
-          equals(Uri.parse("http://pub.dartlang.org/stuff.js")));
+          equals(Uri.parse('http://pub.dartlang.org/stuff.js')));
       expect(trace.frames[1].uri,
-          equals(Uri.parse("http://pub.dartlang.org/stuff.js")));
+          equals(Uri.parse('http://pub.dartlang.org/stuff.js')));
       expect(trace.frames[2].uri,
-          equals(Uri.parse("http://pub.dartlang.org/thing.js")));
+          equals(Uri.parse('http://pub.dartlang.org/thing.js')));
       expect(trace.frames.length, equals(3));
     });
 
@@ -174,12 +174,12 @@ void main() {
           'zip.zap(12, "@)()/<")@http://pub.dartlang.org/thing.js:1');
 
       expect(trace.frames[0].uri,
-          equals(Uri.parse("http://pub.dartlang.org/stuff.js")));
+          equals(Uri.parse('http://pub.dartlang.org/stuff.js')));
       expect(trace.frames[0].member, equals('<fn>'));
       expect(trace.frames[1].uri,
-          equals(Uri.parse("http://pub.dartlang.org/stuff.js")));
+          equals(Uri.parse('http://pub.dartlang.org/stuff.js')));
       expect(trace.frames[2].uri,
-          equals(Uri.parse("http://pub.dartlang.org/thing.js")));
+          equals(Uri.parse('http://pub.dartlang.org/thing.js')));
     });
 
     test('parses a Firefox/Safari stack trace with an empty line correctly',
@@ -190,11 +190,11 @@ void main() {
           'zip.zap(12, "@)()/<")@http://pub.dartlang.org/thing.js:1');
 
       expect(trace.frames[0].uri,
-          equals(Uri.parse("http://pub.dartlang.org/stuff.js")));
+          equals(Uri.parse('http://pub.dartlang.org/stuff.js')));
       expect(trace.frames[1].uri,
-          equals(Uri.parse("http://pub.dartlang.org/stuff.js")));
+          equals(Uri.parse('http://pub.dartlang.org/stuff.js')));
       expect(trace.frames[2].uri,
-          equals(Uri.parse("http://pub.dartlang.org/thing.js")));
+          equals(Uri.parse('http://pub.dartlang.org/thing.js')));
     });
 
     test('parses a Firefox/Safari stack trace with a column number correctly',
@@ -204,13 +204,13 @@ void main() {
           'zip.zap(12, "@)()/<")@http://pub.dartlang.org/thing.js:1');
 
       expect(trace.frames[0].uri,
-          equals(Uri.parse("http://pub.dartlang.org/stuff.js")));
+          equals(Uri.parse('http://pub.dartlang.org/stuff.js')));
       expect(trace.frames[0].line, equals(42));
       expect(trace.frames[0].column, equals(2));
       expect(trace.frames[1].uri,
-          equals(Uri.parse("http://pub.dartlang.org/stuff.js")));
+          equals(Uri.parse('http://pub.dartlang.org/stuff.js')));
       expect(trace.frames[2].uri,
-          equals(Uri.parse("http://pub.dartlang.org/thing.js")));
+          equals(Uri.parse('http://pub.dartlang.org/thing.js')));
     });
 
     test('parses a package:stack_trace stack trace correctly', () {
@@ -219,9 +219,9 @@ void main() {
               'http://dartlang.org/foo/baz.dart        Foo.<fn>.bar');
 
       expect(trace.frames[0].uri,
-          equals(Uri.parse("http://dartlang.org/foo/bar.dart")));
+          equals(Uri.parse('http://dartlang.org/foo/bar.dart')));
       expect(trace.frames[1].uri,
-          equals(Uri.parse("http://dartlang.org/foo/baz.dart")));
+          equals(Uri.parse('http://dartlang.org/foo/baz.dart')));
     });
 
     test('parses a package:stack_trace stack chain correctly', () {
@@ -233,13 +233,13 @@ void main() {
               'http://dartlang.org/foo/quux.dart        Foo.<fn>.bar');
 
       expect(trace.frames[0].uri,
-          equals(Uri.parse("http://dartlang.org/foo/bar.dart")));
+          equals(Uri.parse('http://dartlang.org/foo/bar.dart')));
       expect(trace.frames[1].uri,
-          equals(Uri.parse("http://dartlang.org/foo/baz.dart")));
+          equals(Uri.parse('http://dartlang.org/foo/baz.dart')));
       expect(trace.frames[2].uri,
-          equals(Uri.parse("http://dartlang.org/foo/bang.dart")));
+          equals(Uri.parse('http://dartlang.org/foo/bang.dart')));
       expect(trace.frames[3].uri,
-          equals(Uri.parse("http://dartlang.org/foo/quux.dart")));
+          equals(Uri.parse('http://dartlang.org/foo/quux.dart')));
     });
 
     test('parses a real package:stack_trace stack trace correctly', () {
@@ -283,8 +283,8 @@ http://pub.dartlang.org/thing.dart 1:100  zip.<fn>.zap
             '#3      baz (dart:async:15:0)\n'));
   });
 
-  group("folding", () {
-    group(".terse", () {
+  group('folding', () {
+    group('.terse', () {
       test('folds core frames together bottom-up', () {
         var trace = Trace.parse('''
 #1 top (dart:async/future.dart:0:2)
@@ -343,7 +343,7 @@ dart:core  bottom
       });
 
       test("won't panic on an empty trace", () {
-        expect(Trace.parse("").terse.toString(), equals(""));
+        expect(Trace.parse('').terse.toString(), equals(''));
       });
     });
 

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -17,7 +17,8 @@ Matcher frameLibrary(matcher) =>
 ///
 /// [description] should be a noun phrase that describes the relation of the
 /// output of [transformation] to its input.
-Matcher transform(transformation(value), matcher, String description) =>
+Matcher transform(
+        void Function(dynamic) transformation, matcher, String description) =>
     _TransformMatcher(transformation, wrapMatcher(matcher), description);
 
 class _TransformMatcher extends Matcher {
@@ -27,9 +28,11 @@ class _TransformMatcher extends Matcher {
 
   _TransformMatcher(this._transformation, this._matcher, this._description);
 
+  @override
   bool matches(item, Map matchState) =>
       _matcher.matches(_transformation(item), matchState);
 
+  @override
   Description describe(Description description) =>
       description.add(_description).add(' ').addDescriptionOf(_matcher);
 }

--- a/test/vm_test.dart
+++ b/test/vm_test.dart
@@ -47,7 +47,7 @@ void main() {
     });
 
     test('.from handles a stack overflow trace correctly', () {
-      overflow() => overflow();
+      void overflow() => overflow();
 
       var trace;
       try {


### PR DESCRIPTION
- always_declare_return_types
- annotate_overrides
- prefer_conditional_assignment
- prefer_if_null_operators
- prefer_single_quotes
- unnecessary_this
- use_function_type_syntax_for_parameters

Remove local lint config which duplicates enabled rules.

Ignore `prefer_spread_collections` for now. We should publish once more
before bumping the min SDK.