### PR TITLE
Drop a workaround for a resolved issue

### DIFF
--- a/lib/src/lazy_trace.dart
+++ b/lib/src/lazy_trace.dart
@@ -29,7 +29,4 @@ class LazyTrace implements Trace {
   Trace foldFrames(bool predicate(Frame frame), {bool terse = false}) =>
       LazyTrace(() => _trace.foldFrames(predicate, terse: terse));
   String toString() => _trace.toString();
-
-  // Work around issue 14075.
-  set frames(_) => throw UnimplementedError();
 }


### PR DESCRIPTION
https://github.com/dart-lang/sdk/issues/14075 has been closed for a long
time.

This class in not in the public interface for the package so it should
not be breaking to remove the throwing setter.