### PR TITLE
Fix newly surface errors after cleanup

### DIFF
--- a/lib/src/chain.dart
+++ b/lib/src/chain.dart
@@ -73,7 +73,7 @@ class Chain implements StackTrace {
   ///
   /// If [callback] returns a value, it will be returned by [capture] as well.
   static T capture<T>(T Function() callback,
-      {void Function(Object error, Chain)? onError,
+      {void Function(dynamic error, Chain)? onError,
       bool when = true,
       bool errorZone = true}) {
     if (!errorZone && onError != null) {
@@ -82,7 +82,7 @@ class Chain implements StackTrace {
     }
 
     if (!when) {
-      void Function(Object, StackTrace) newOnError;
+      late void Function(Object, StackTrace) newOnError;
       if (onError != null) {
         void wrappedOnError(Object error, StackTrace? stackTrace) {
           onError(
@@ -102,7 +102,7 @@ class Chain implements StackTrace {
     return runZoned(() {
       try {
         return callback();
-      } catch (error, stackTrace) {
+      } on Object catch (error, stackTrace) {
         // TODO(nweiz): Don't special-case this when issue 19566 is fixed.
         Zone.current.handleUncaughtError(error, stackTrace);
 

--- a/lib/src/chain.dart
+++ b/lib/src/chain.dart
@@ -73,7 +73,7 @@ class Chain implements StackTrace {
   ///
   /// If [callback] returns a value, it will be returned by [capture] as well.
   static T capture<T>(T Function() callback,
-      {void Function(dynamic error, Chain)? onError,
+      {void Function(Object error, Chain)? onError,
       bool when = true,
       bool errorZone = true}) {
     if (!errorZone && onError != null) {

--- a/lib/src/frame.dart
+++ b/lib/src/frame.dart
@@ -168,7 +168,7 @@ class Frame {
         Frame parseLocation(String location, String member) {
           var evalMatch = _v8EvalLocation.firstMatch(location);
           while (evalMatch != null) {
-            location = evalMatch[1];
+            location = evalMatch[1]!;
             evalMatch = _v8EvalLocation.firstMatch(location);
           }
 
@@ -189,7 +189,7 @@ class Frame {
           // lists anonymous functions within eval as "<anonymous>", while IE10
           // lists them as "Anonymous function".
           return parseLocation(
-              match[2],
+              match[2]!,
               match[1]!
                   .replaceAll('<anonymous>', '<fn>')
                   .replaceAll('Anonymous function', '<fn>')
@@ -197,7 +197,7 @@ class Frame {
         } else {
           // The second form looks like " at LOCATION", and is used for
           // anonymous functions.
-          return parseLocation(match[3], '<fn>');
+          return parseLocation(match[3]!, '<fn>');
         }
       });
 
@@ -219,9 +219,9 @@ class Frame {
       _catchFormatException(frame, () {
         final match = _firefoxEvalLocation.firstMatch(frame);
         if (match == null) return UnparsedFrame(frame);
-        var member = match[1].replaceAll('/<', '');
-        final uri = _uriOrPathToUri(match[2]);
-        final line = int.parse(match[3]);
+        var member = match[1]!.replaceAll('/<', '');
+        final uri = _uriOrPathToUri(match[2]!);
+        final line = int.parse(match[3]!);
         if (member.isEmpty || member == 'anonymous') {
           member = '<fn>';
         }
@@ -233,7 +233,7 @@ class Frame {
         var match = _firefoxSafariFrame.firstMatch(frame);
         if (match == null) return UnparsedFrame(frame);
 
-        if (match[3].contains(' line ')) {
+        if (match[3]!.contains(' line ')) {
           return Frame._parseFirefoxEval(frame);
         }
 

--- a/lib/src/stack_zone_specification.dart
+++ b/lib/src/stack_zone_specification.dart
@@ -11,7 +11,7 @@ import 'trace.dart';
 import 'utils.dart';
 
 /// A function that handles errors in the zone wrapped by [Chain.capture].
-typedef _ChainHandler = void Function(dynamic error, Chain chain);
+typedef _ChainHandler = void Function(Object error, Chain chain);
 
 /// A class encapsulating the zone specification for a [Chain.capture] zone.
 ///

--- a/lib/src/stack_zone_specification.dart
+++ b/lib/src/stack_zone_specification.dart
@@ -144,8 +144,8 @@ class StackZoneSpecification {
 
   /// Looks up the chain associated with [stackTrace] and passes it either to
   /// [_onError] or [parent]'s error handler.
-  void _handleUncaughtError(
-      Zone self, ZoneDelegate parent, Zone zone, error, StackTrace stackTrace) {
+  void _handleUncaughtError(Zone self, ZoneDelegate parent, Zone zone,
+      Object error, StackTrace stackTrace) {
     if (_disabled) {
       parent.handleUncaughtError(zone, error, stackTrace);
       return;
@@ -163,7 +163,7 @@ class StackZoneSpecification {
       // TODO(rnystrom): Is the null-assertion correct here? It is nullable in
       // Zone. Should we check for that here?
       self.parent!.runBinary(_onError!, error, stackChain);
-    } catch (newError, newStackTrace) {
+    } on Object catch (newError, newStackTrace) {
       if (identical(newError, error)) {
         parent.handleUncaughtError(zone, error, stackChain);
       } else {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ description: A package for manipulating stack traces and printing them readably.
 homepage: https://github.com/dart-lang/stack_trace
 
 environment:
-  sdk: '>=2.8.0-dev.10 <3.0.0'
+  sdk: '>=2.9.0-dev <3.0.0'
 
 dependencies:
   path: ^1.2.0

--- a/test/chain/dart2js_test.dart
+++ b/test/chain/dart2js_test.dart
@@ -90,7 +90,7 @@ void main() {
             expect(chain.traces, hasLength(2));
             completer.complete();
           }
-        } catch (error, stackTrace) {
+        } on Object catch (error, stackTrace) {
           completer.completeError(error, stackTrace);
         }
       });
@@ -146,7 +146,7 @@ void main() {
         }, onError: (error, chain) {
           expect(error, equals('error'));
           expect(chain.traces, hasLength(2));
-          throw error;
+          throw error as Object;
         });
       }, onError: (error, chain) {
         try {
@@ -154,7 +154,7 @@ void main() {
           expect(chain, isA<Chain>());
           expect(chain.traces, hasLength(2));
           completer.complete();
-        } catch (error, stackTrace) {
+        } on Object catch (error, stackTrace) {
           completer.completeError(error, stackTrace);
         }
       });
@@ -174,7 +174,7 @@ void main() {
         expect(chain, isA<Chain>());
         expect(chain.traces, hasLength(2));
         completer.complete();
-      } catch (error, stackTrace) {
+      } on Object catch (error, stackTrace) {
         completer.completeError(error, stackTrace);
       }
     });

--- a/test/chain/vm_test.dart
+++ b/test/chain/vm_test.dart
@@ -156,7 +156,7 @@ void main() {
                 contains(frameMember(startsWith('inPeriodicTimer'))));
             completer.complete();
           }
-        } catch (error, stackTrace) {
+        } on Object catch (error, stackTrace) {
           completer.completeError(error, stackTrace);
         }
       });
@@ -241,7 +241,7 @@ void main() {
           expect(error, equals('error'));
           expect(chain.traces[1].frames,
               contains(frameMember(startsWith('inMicrotask'))));
-          throw error;
+          throw error as Object;
         });
       }, onError: (error, chain) {
         try {
@@ -250,7 +250,7 @@ void main() {
           expect(chain.traces[1].frames,
               contains(frameMember(startsWith('inMicrotask'))));
           completer.complete();
-        } catch (error, stackTrace) {
+        } on Object catch (error, stackTrace) {
           completer.completeError(error, stackTrace);
         }
       });
@@ -271,7 +271,7 @@ void main() {
         expect(chain.traces[1].frames,
             contains(frameMember(startsWith('inMicrotask'))));
         completer.complete();
-      } catch (error, stackTrace) {
+      } on Object catch (error, stackTrace) {
         completer.completeError(error, stackTrace);
       }
     });
@@ -481,7 +481,7 @@ void main() {
       'chain', () {
     // Disable the test package's chain-tracking.
     return Chain.disable(() async {
-      StackTrace trace;
+      late StackTrace trace;
       await Chain.capture(() async {
         try {
           throw 'error';


### PR DESCRIPTION
Some cleanup on the master branch surfaced new static errors in the
migration branch.

- More variable types (from `var` with an uninitialized variable)
  requires additional `late` or additional casts.
- Use `on Object catch` when the static type of the error shouldn't by
  `dynamic` since we now disallow implicit casts from `dynamic`. These
  won't be necessary after a catch with no `on` clause gets an inferred
  type of `Object` instead of `dynamic`.
- Add some more `!` in places where adding more argument types which
  were previously implicit dynamic caused less dynamic throughout the
  body of a function.