### PR TITLE
Loosen argument type in callback

### DIFF
--- a/lib/src/chain.dart
+++ b/lib/src/chain.dart
@@ -73,7 +73,7 @@ class Chain implements StackTrace {
   ///
   /// If [callback] returns a value, it will be returned by [capture] as well.
   static T capture<T>(T Function() callback,
-      {void Function(Object error, Chain) onError,
+      {void Function(dynamic error, Chain) onError,
       bool when = true,
       bool errorZone = true}) {
     if (!errorZone && onError != null) {


### PR DESCRIPTION
The type was technically changed when refactoring to function type
syntax, restore the `dynamic` but make it explicit.

This surfaces as a static problem in the null safety branch. Fix it on
the master branch as well for consistency.