### PR TITLE
Change back to Object from dynamic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## 1.9.4-dev
 
 * Added support for firefox anonymous stack traces
+* Change the argument type to `Chain.capture` from `Function(dynamic, Chain)` to
+  `Function(Object, Chain)`. Existing functions which take `dynamic` are still
+  fine, but new uses can have a safer type.
 
 ## 1.9.3
 

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -4,3 +4,7 @@ analyzer:
     implicit-casts: false
   errors:
     prefer_spread_collections: ignore
+
+linter:
+  rules:
+    - avoid_private_typedef_functions

--- a/lib/src/chain.dart
+++ b/lib/src/chain.dart
@@ -73,7 +73,7 @@ class Chain implements StackTrace {
   ///
   /// If [callback] returns a value, it will be returned by [capture] as well.
   static T capture<T>(T Function() callback,
-      {void Function(dynamic error, Chain) onError,
+      {void Function(Object error, Chain) onError,
       bool when = true,
       bool errorZone = true}) {
     if (!errorZone && onError != null) {

--- a/lib/src/stack_zone_specification.dart
+++ b/lib/src/stack_zone_specification.dart
@@ -10,9 +10,6 @@ import 'lazy_trace.dart';
 import 'trace.dart';
 import 'utils.dart';
 
-/// A function that handles errors in the zone wrapped by [Chain.capture].
-typedef _ChainHandler = void Function(dynamic error, Chain chain);
-
 /// A class encapsulating the zone specification for a [Chain.capture] zone.
 ///
 /// Until they're materialized and exposed to the user, stack chains are tracked
@@ -56,7 +53,7 @@ class StackZoneSpecification {
   ///
   /// If this is null, that indicates that any unhandled errors should be passed
   /// to the parent zone.
-  final _ChainHandler _onError;
+  final void Function(Object error, Chain) _onError;
 
   /// The most recent node of the current stack chain.
   _Node _currentNode;


### PR DESCRIPTION
See https://github.com/dart-lang/stack_trace/pull/64#discussion_r410279004

Enable and fix the lint `avoid_private_typedef_functions`.