### PR TITLE
Fix parsing for URIs with a : in the authority

### DIFF
--- a/lib/src/frame.dart
+++ b/lib/src/frame.dart
@@ -21,8 +21,8 @@ final _v8Frame =
     RegExp(r'^\s*at (?:(\S.*?)(?: \[as [^\]]+\])? \((.*)\)|(.*))$');
 
 // https://example.com/stuff.dart.js:560:28
-// http://pub.dartlang.org/stuff.dart.js:560
-final _v8UrlLocation = RegExp(r'^(.*?):(\d+)(?::(\d+))?|native$');
+// https://example.com/stuff.dart.js:560
+final _v8UrlLocation = RegExp(r'^(.*?):(\d+)(?::(\d+))?$|native$');
 
 // eval as function (https://example.com/stuff.dart.js:560:28), efn:3:28
 // eval as function (https://example.com/stuff.dart.js:560:28)

--- a/test/frame_test.dart
+++ b/test/frame_test.dart
@@ -89,6 +89,16 @@ void main() {
       expect(frame.member, equals('VW.call\$0'));
     });
 
+    test('parses a stack frame with a : in the authority', () {
+      var frame = Frame.parseV8('    at VW.call\$0 '
+          '(http://localhost:8080/stuff.dart.js:560:28)');
+      expect(
+          frame.uri, equals(Uri.parse('http://localhost:8080/stuff.dart.js')));
+      expect(frame.line, equals(560));
+      expect(frame.column, equals(28));
+      expect(frame.member, equals('VW.call\$0'));
+    });
+
     test('parses a stack frame with an absolute POSIX path correctly', () {
       var frame = Frame.parseV8('    at VW.call\$0 '
           '(/path/to/stuff.dart.js:560:28)');


### PR DESCRIPTION
Add a `$` to enforce that the `:(\d+)` is at the end of the String. The
previous regex could pick up too little - we end up with
`http://localhost` as the URI and the port as the line.

Switch from `pub.dartlang.org` to `example.com` to avoid references
to legacy URLs.