### PR TITLE
Handle new style VM data URI frames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.9.5
+
+* Parse the format for `data:` URIs that the Dart VM has used since `2.2.0`.
+
 ## 1.9.4
 
 * Add support for firefox anonymous stack traces.

--- a/lib/src/frame.dart
+++ b/lib/src/frame.dart
@@ -149,7 +149,9 @@ class Frame {
         var member = match[1]
             .replaceAll(_asyncBody, '<async>')
             .replaceAll('<anonymous closure>', '<fn>');
-        var uri = Uri.parse(match[2]);
+        var uri = match[2].startsWith('<data:')
+            ? Uri.dataFromString('')
+            : Uri.parse(match[2]);
 
         var lineAndColumn = match[3].split(':');
         var line =

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: stack_trace
-version: 1.9.4
+version: 1.9.5
 
 description: A package for manipulating stack traces and printing them readably.
 homepage: https://github.com/dart-lang/stack_trace

--- a/test/frame_test.dart
+++ b/test/frame_test.dart
@@ -568,9 +568,15 @@ baz@https://pub.dev/buz.js:56355:55
           equals(path.join('foo', 'bar.dart')));
     });
 
-    test('truncates data: URIs', () {
+    test('truncates legacy data: URIs', () {
       var frame = Frame.parseVM(
           '#0 Foo (data:application/dart;charset=utf-8,blah:0:0)');
+      expect(frame.library, equals('data:...'));
+    });
+
+    test('truncates data: URIs', () {
+      var frame = Frame.parseVM(
+          '#0      main (<data:application/dart;charset=utf-8>:1:15)');
       expect(frame.library, equals('data:...'));
     });
   });


### PR DESCRIPTION
See https://github.com/dart-lang/test/issues/1261

Somewhere between Dart `2.1.0` and Dart `2.2.0` the output from the VM
for stack frames in `data:` URIs changed. The new format wraps with `<>`
and does not include the full URI.

Check specifically whether the matched "uri" is instead a truncated and
bracketed `data:` URI and treat it as if it were a valid empty data URI.