### PR TITLE
Fix static null error after git merge

### DIFF
--- a/lib/src/frame.dart
+++ b/lib/src/frame.dart
@@ -184,7 +184,8 @@ class Frame {
 
           final uri = _uriOrPathToUri(urlMatch[1]!);
           final line = int.parse(urlMatch[2]!);
-          final column = urlMatch[3] != null ? int.parse(urlMatch[3]) : null;
+          final columnMatch = urlMatch[3];
+          final column = columnMatch != null ? int.parse(columnMatch) : null;
           return Frame(uri, line, column, member);
         }
 


### PR DESCRIPTION
Missed a `!` when using `urlMatch[3]` as a non-null String. Pull it out
instead to a local variable so that the prior null check satisfies flow
analysis.