### PR TITLE
Avoid converting stacktrace to nullable and then null checking it.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.10.0-nullsafety.2
+
+* Forward fix for a change in SDK type promotion behavior.
+
 ## 1.10.0-nullsafety.1
 
 * Allow 2.10 stable and 2.11.0 dev SDK versions.

--- a/lib/src/stack_zone_specification.dart
+++ b/lib/src/stack_zone_specification.dart
@@ -99,8 +99,8 @@ class StackZoneSpecification {
       return LazyChain(() => Chain.parse(trace!.toString()));
     } else {
       if (trace is! Trace) {
-        StackTrace? original = trace;
-        trace = LazyTrace(() => Trace.parse(_trimVMChain(original!)));
+        StackTrace original = trace;
+        trace = LazyTrace(() => Trace.parse(_trimVMChain(original)));
       }
 
       return _Node(trace, previous).toChain();

--- a/lib/src/stack_zone_specification.dart
+++ b/lib/src/stack_zone_specification.dart
@@ -99,7 +99,7 @@ class StackZoneSpecification {
       return LazyChain(() => Chain.parse(trace!.toString()));
     } else {
       if (trace is! Trace) {
-        StackTrace original = trace;
+        var original = trace;
         trace = LazyTrace(() => Trace.parse(_trimVMChain(original)));
       }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: stack_trace
-version: 1.10.0-nullsafety.1
+version: 1.10.0-nullsafety.2
 description: A package for manipulating stack traces and printing them readably.
 homepage: https://github.com/dart-lang/stack_trace
 


### PR DESCRIPTION
The Dart implementation will soon be changed so that a declaration
such as `T? x = y`, where `y` has a non-nullable type, automatically
promotes `x` to a non-nullable type.  This will in turn cause a
warning if a non-nullable value is assigned to a nullable variable and
then null checked.

We're currently doing that in one place, and there's no need to, so
remove the unnecessary type conversion and null check.