### PR TITLE
Prepare to publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.10.0-nullsafety.3-dev
+## 1.10.0-nullsafety.3
 
 * Fix bug parsing asynchronous suspension gap markers at the end of stack
   traces.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,11 @@
 name: stack_trace
-version: 1.10.0-nullsafety.3-dev
+version: 1.10.0-nullsafety.3
 description: A package for manipulating stack traces and printing them readably.
 homepage: https://github.com/dart-lang/stack_trace
 
 environment:
   # This must remain a tight constraint until nnbd is stable
-  sdk: '>=2.10.0-0 <2.11.0'
+  sdk: '>=2.11.0-0 <2.11.0'
 
 dependencies:
   path: ^1.8.0-nullsafety


### PR DESCRIPTION
Bump the min SDk to `2.11.0-0`. There were changes previously which
appear to depend on changes in the SDK that were not reflected in the
lower bound constraint, bump to a much more recent SDK for safety.