### PR TITLE
Allow earlier SDKs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.10.0-nullsafety.4
+
+* Allow the `2.10.0` stable and dev SDKs.
+
 ## 1.10.0-nullsafety.3
 
 * Fix bug parsing asynchronous suspension gap markers at the end of stack

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,11 @@
 name: stack_trace
-version: 1.10.0-nullsafety.3
+version: 1.10.0-nullsafety.4
 description: A package for manipulating stack traces and printing them readably.
 homepage: https://github.com/dart-lang/stack_trace
 
 environment:
   # This must remain a tight constraint until nnbd is stable
-  sdk: '>=2.11.0-0 <2.11.0'
+  sdk: '>=2.10.0-0.0.dev <2.11.0'
 
 dependencies:
   path: ^1.8.0-nullsafety


### PR DESCRIPTION
This was bumped because it wasn't clear which SDKs it worked with,
however a comment on an earlier PR shows that it is compatible with
early SDKs.