### PR TITLE
Bump SDK constraints for pub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
-## 1.10.0-nullsafety.6-dev
+## 1.10.0-nullsafety.6
 
 * Fix bug parsing asynchronous suspension gap markers at the end of stack
   traces, when parsing with `Trace.parse` and `Chain.parse`.
+* Update SDK constraints to `>=2.12.0-0 <3.0.0` based on beta release
+  guidelines.
 
 ## 1.10.0-nullsafety.5
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,10 @@
 name: stack_trace
-version: 1.10.0-nullsafety.6-dev
+version: 1.10.0-nullsafety.6
 description: A package for manipulating stack traces and printing them readably.
 homepage: https://github.com/dart-lang/stack_trace
 
 environment:
-  # This must remain a tight constraint until nnbd is stable
-  sdk: '>=2.10.0-0.0.dev <2.12.0'
+  sdk: ">=2.12.0-0 <3.0.0"
 
 dependencies:
   path: ^1.8.0-nullsafety


### PR DESCRIPTION
Use a 2.12.0 lower bound since pub does not understand allowed
experiments for earlier versions.

Use a 3.0.0 upper bound to avoid a warning in pub and to give some
flexibility in publishing for stable.