### PR TITLE
Remove workaround for truncated last lines

### DIFF
--- a/lib/src/trace.dart
+++ b/lib/src/trace.dart
@@ -151,22 +151,7 @@ class Trace implements StackTrace {
         .replaceAll(vmChainGap, '')
         .split('\n')
         .where((line) => line.isNotEmpty);
-
-    if (lines.isEmpty) {
-      return [];
-    }
-
-    var frames = lines
-        .take(lines.length - 1)
-        .map((line) => Frame.parseVM(line))
-        .toList();
-
-    // TODO(nweiz): Remove this when issue 23614 is fixed.
-    if (!lines.last.endsWith('.da')) {
-      frames.add(Frame.parseVM(lines.last));
-    }
-
-    return frames;
+    return [for (var line in lines) Frame.parseVM(line)];
   }
 
   /// Parses a string representation of a Chrome/V8 stack trace.


### PR DESCRIPTION
The referenced SDK issue has been closed.
https://github.com/dart-lang/sdk/issues/23614

Remove the workaround that handles the last line specially and simplify
to a collection for loop.