### PR TITLE
migrate from `dartanalyzer` to `dart analyze`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ jobs:
     - stage: analyze_and_format
       name: "Analyzer"
       os: linux
-      script: dartanalyzer --enable-experiment=non-nullable --fatal-warnings --fatal-infos .
+      script: dart analyze --fatal-infos .
     - stage: analyze_and_format
       name: "Format"
       os: linux


### PR DESCRIPTION
the experiment is no longer required and warnings are fatal by default

/cc @jakemac53 @natebosch 