### PR TITLE
Revert "Remove workaround for truncated last lines (#100)"

### DIFF
--- a/lib/src/trace.dart
+++ b/lib/src/trace.dart
@@ -151,7 +151,22 @@ class Trace implements StackTrace {
         .replaceAll(vmChainGap, '')
         .split('\n')
         .where((line) => line.isNotEmpty);
-    return [for (var line in lines) Frame.parseVM(line)];
+
+    if (lines.isEmpty) {
+      return [];
+    }
+
+    var frames = lines
+        .take(lines.length - 1)
+        .map((line) => Frame.parseVM(line))
+        .toList();
+
+    // TODO(nweiz): Remove this when issue 23614 is fixed.
+    if (!lines.last.endsWith('.da')) {
+      frames.add(Frame.parseVM(lines.last));
+    }
+
+    return frames;
   }
 
   /// Parses a string representation of a Chrome/V8 stack trace.


### PR DESCRIPTION
This reverts https://github.com/dart-lang/stack_trace/commit/c252c7b63f16b8f561486d27e2bd0679f5fe3ff8.

This never made it into a published version, so we are reverting it prior to the stable release. We can re-land it after the first stable is released.