### PR TITLE
Fix test for wrapping in error zone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 1.10.1-dev
+
 ## 1.10.0
 
 * Stable release for null safety.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: stack_trace
-version: 1.10.0
+version: 1.10.1-dev
 description: A package for manipulating stack traces and printing them readably.
 homepage: https://github.com/dart-lang/stack_trace
 

--- a/test/chain/chain_test.dart
+++ b/test/chain/chain_test.dart
@@ -60,13 +60,15 @@ void main() {
       }, onError: expectAsync2((error, chain) {
         expect(error, equals('oh no'));
         expect(chain, isA<Chain>());
-      }));
+      })).then(expectAsync1((_) {}, count: 0),
+          onError: expectAsync2((_, __) {}, count: 0));
     });
 
     test('with no onError blocks errors', () {
       runZonedGuarded(() {
-        var future = Chain.capture(() => Future.error('oh no'), when: false);
-        future.then(expectAsync1((_) {}, count: 0));
+        Chain.capture(() => Future.error('oh no')).then(
+            expectAsync1((_) {}, count: 0),
+            onError: expectAsync2((_, __) {}, count: 0));
       }, expectAsync2((error, chain) {
         expect(error, equals('oh no'));
         expect(chain, isA<Chain>());


### PR DESCRIPTION
When this test was written it had a bug - it should not pass
`when: false` because that argument makes the method ignore the
`errorZone` argument entirely. Omitting the argument allows the default
`errorZone: true` behavior. The bug in the test was masked by the fact
that `package:test` had previously run tests wrapped in a chain
capturing zone by default.

Remove the `when` argument to correct the test. Add an `onError`
argument to the `.then` call to make the test stronger and assert that
the resulting future does not complete at all - either with a value or
an error. Also add the same check that the future does not complete on
another test for error blocking.