### PR TITLE
Added zoneValues to Chain.capture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
-## 1.10.1-dev
-* Added the option for custom `zoneValues` on `Chain.capture` 
+## 1.11.0-dev
+* Added the param `zoneValues` to `Chain.capture` to be able to use 
+  custom zone values with the `runZoned` internal calls 
 
 ## 1.10.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## 1.10.1-dev
+* Added the option for custom `zoneValues` on `Chain.capture` 
 
 ## 1.10.0
 

--- a/lib/src/chain.dart
+++ b/lib/src/chain.dart
@@ -75,7 +75,8 @@ class Chain implements StackTrace {
   static T capture<T>(T Function() callback,
       {void Function(Object error, Chain)? onError,
       bool when = true,
-      bool errorZone = true}) {
+      bool errorZone = true,
+        Map<Object?, Object?>? zoneValues}) {
     if (!errorZone && onError != null) {
       throw ArgumentError.value(
           onError, 'onError', 'must be null if errorZone is false');
@@ -104,7 +105,11 @@ class Chain implements StackTrace {
       }
     },
         zoneSpecification: spec.toSpec(),
-        zoneValues: {_specKey: spec, StackZoneSpecification.disableKey: false});
+        zoneValues: {
+          ...?zoneValues,
+          _specKey: spec,
+          StackZoneSpecification.disableKey: false
+    });
   }
 
   /// If [when] is `true` and this is called within a [Chain.capture] zone, runs

--- a/lib/src/chain.dart
+++ b/lib/src/chain.dart
@@ -72,6 +72,8 @@ class Chain implements StackTrace {
   ///  If [errorZone] is `false`, [onError] must be `null`.
   ///
   /// If [callback] returns a value, it will be returned by [capture] as well.
+  /// 
+  /// [zoneValues] is added to the [runZoned] calls.
   static T capture<T>(T Function() callback,
       {void Function(Object error, Chain)? onError,
       bool when = true,
@@ -83,10 +85,10 @@ class Chain implements StackTrace {
     }
 
     if (!when) {
-      if (onError == null) return runZoned(callback);
+      if (onError == null) return runZoned(callback, zoneValues: zoneValues);
       return runZonedGuarded(callback, (error, stackTrace) {
         onError(error, Chain.forTrace(stackTrace));
-      }) as T;
+      }, zoneValues: zoneValues) as T;
     }
 
     var spec = StackZoneSpecification(onError, errorZone: errorZone);

--- a/lib/src/chain.dart
+++ b/lib/src/chain.dart
@@ -72,13 +72,13 @@ class Chain implements StackTrace {
   ///  If [errorZone] is `false`, [onError] must be `null`.
   ///
   /// If [callback] returns a value, it will be returned by [capture] as well.
-  /// 
+  ///
   /// [zoneValues] is added to the [runZoned] calls.
   static T capture<T>(T Function() callback,
       {void Function(Object error, Chain)? onError,
       bool when = true,
       bool errorZone = true,
-        Map<Object?, Object?>? zoneValues}) {
+      Map<Object?, Object?>? zoneValues}) {
     if (!errorZone && onError != null) {
       throw ArgumentError.value(
           onError, 'onError', 'must be null if errorZone is false');
@@ -105,12 +105,10 @@ class Chain implements StackTrace {
         // where T is a nullable type continue to work.
         return null as T;
       }
-    },
-        zoneSpecification: spec.toSpec(),
-        zoneValues: {
-          ...?zoneValues,
-          _specKey: spec,
-          StackZoneSpecification.disableKey: false
+    }, zoneSpecification: spec.toSpec(), zoneValues: {
+      ...?zoneValues,
+      _specKey: spec,
+      StackZoneSpecification.disableKey: false
     });
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: stack_trace
-version: 1.10.1-dev
+version: 1.11.0-dev
 description: A package for manipulating stack traces and printing them readably.
 homepage: https://github.com/dart-lang/stack_trace
 

--- a/test/chain/chain_test.dart
+++ b/test/chain/chain_test.dart
@@ -118,11 +118,9 @@ void main() {
   });
 
   test('Chain.capture() with custom zoneValues', () {
-      return Chain.capture(() {
-        expect(Zone.current[#enabled], true);
-      }, zoneValues: {
-        #enabled: true
-      });
+    return Chain.capture(() {
+      expect(Zone.current[#enabled], true);
+    }, zoneValues: {#enabled: true});
   });
 
   group('Chain.disable()', () {

--- a/test/chain/chain_test.dart
+++ b/test/chain/chain_test.dart
@@ -117,6 +117,14 @@ void main() {
     });
   });
 
+  test('Chain.capture() with custom zoneValues', () {
+      return Chain.capture(() {
+        expect(Zone.current[#enabled], true);
+      }, zoneValues: {
+        #enabled: true
+      });
+  });
+
   group('Chain.disable()', () {
     test('disables chain-tracking', () {
       return Chain.disable(() {


### PR DESCRIPTION
Edited `Chain.capture` to accept custom `zoneValues` so you don't need to spawn another `runZoned`