### PR TITLE
A bunch of cleanup, prepare for v1.11.0

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -22,8 +22,8 @@ jobs:
       matrix:
         sdk: [dev]
     steps:
-      - uses: actions/checkout@v2
-      - uses: dart-lang/setup-dart@v1.0
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+      - uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
         with:
           sdk: ${{ matrix.sdk }}
       - id: install
@@ -47,10 +47,10 @@ jobs:
       matrix:
         # Add macos-latest and/or windows-latest if relevant for this package.
         os: [ubuntu-latest]
-        sdk: [2.12.0, dev]
+        sdk: [2.18.0, dev]
     steps:
-      - uses: actions/checkout@v2
-      - uses: dart-lang/setup-dart@v1.0
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+      - uses: dart-lang/setup-dart@6a218f2413a3e78e9087f638a238f6b40893203d
         with:
           sdk: ${{ matrix.sdk }}
       - id: install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
-## 1.11.0-dev
+## 1.11.0
 
-* Added the param `zoneValues` to `Chain.capture` to be able to use custom zone
-  values with the `runZoned` internal calls 
+* Added the parameter `zoneValues` to `Chain.capture` to be able to use custom
+  zone values with the `runZoned` internal calls.
 * Populate the pubspec `repository` field.
-* Switch to `package:lints`.
+* Require Dart 2.18 or greater
 
 ## 1.10.0
 

--- a/README.md
+++ b/README.md
@@ -80,35 +80,25 @@ Here's an example of some code that doesn't capture its stack chains:
 import 'dart:async';
 
 void main() {
-  scheduleAsync();
+  _scheduleAsync();
 }
 
-void scheduleAsync() {
-  return new Future.delayed(new Duration(seconds: 1))
-      .then((_) => runAsync());
+void _scheduleAsync() {
+  Future.delayed(Duration(seconds: 1)).then((_) => _runAsync());
 }
 
-void runAsync() {
+void _runAsync() {
   throw 'oh no!';
 }
 ```
 
 If we run this, it prints the following:
 
-    Uncaught Error: oh no!
-    Stack Trace: 
-    #0      runAsync (file:///usr/local/google-old/home/goog/dart/dart/test.dart:13:3)
-    #1      scheduleAsync.<anonymous closure> (file:///usr/local/google-old/home/goog/dart/dart/test.dart:9:28)
-    #2      _rootRunUnary (dart:async/zone.dart:717)
-    #3      _RootZone.runUnary (dart:async/zone.dart:854)
-    #4      _Future._propagateToListeners.handleValueCallback (dart:async/future_impl.dart:488)
-    #5      _Future._propagateToListeners (dart:async/future_impl.dart:571)
-    #6      _Future._complete (dart:async/future_impl.dart:317)
-    #7      _SyncCompleter.complete (dart:async/future_impl.dart:44)
-    #8      Future.Future.delayed.<anonymous closure> (dart:async/future.dart:219)
-    #9      _createTimer.<anonymous closure> (dart:async-patch/timer_patch.dart:11)
-    #10     _handleTimeout (dart:io/timer_impl.dart:292)
-    #11     _RawReceivePortImpl._handleMessage (dart:isolate-patch/isolate_patch.dart:115)
+    Unhandled exception:
+    oh no!
+    #0      _runAsync (file:///Users/kevmoo/github/stack_trace/example/example.dart:12:3)
+    #1      _scheduleAsync.<anonymous closure> (file:///Users/kevmoo/github/stack_trace/example/example.dart:8:52)
+    <asynchronous suspension>
 
 Notice how there's no mention of `main` in that stack trace. All we know is that
 the error was in `runAsync`; we don't know why `runAsync` was called.
@@ -121,72 +111,42 @@ import 'dart:async';
 import 'package:stack_trace/stack_trace.dart';
 
 void main() {
-  Chain.capture(() {
-    scheduleAsync();
-  });
+  Chain.capture(_scheduleAsync);
 }
 
-void scheduleAsync() {
-  new Future.delayed(new Duration(seconds: 1))
-      .then((_) => runAsync());
+void _scheduleAsync() {
+  Future.delayed(Duration(seconds: 1)).then((_) => _runAsync());
 }
 
-void runAsync() {
+void _runAsync() {
   throw 'oh no!';
 }
 ```
 
 Now if we run it, it prints this:
 
-    Uncaught Error: oh no!
-    Stack Trace: 
-    test.dart 17:3                                                runAsync
-    test.dart 13:28                                               scheduleAsync.<fn>
-    package:stack_trace/src/stack_zone_specification.dart 129:26  registerUnaryCallback.<fn>.<fn>
-    package:stack_trace/src/stack_zone_specification.dart 174:15  StackZoneSpecification._run
-    package:stack_trace/src/stack_zone_specification.dart 177:7   StackZoneSpecification._run
-    package:stack_trace/src/stack_zone_specification.dart 175:7   StackZoneSpecification._run
-    package:stack_trace/src/stack_zone_specification.dart 129:18  registerUnaryCallback.<fn>
-    dart:async/zone.dart 717                                      _rootRunUnary
-    dart:async/zone.dart 449                                      _ZoneDelegate.runUnary
-    dart:async/zone.dart 654                                      _CustomizedZone.runUnary
-    dart:async/future_impl.dart 488                               _Future._propagateToListeners.handleValueCallback
-    dart:async/future_impl.dart 571                               _Future._propagateToListeners
-    dart:async/future_impl.dart 317                               _Future._complete
-    dart:async/future_impl.dart 44                                _SyncCompleter.complete
-    dart:async/future.dart 219                                    Future.Future.delayed.<fn>
-    package:stack_trace/src/stack_zone_specification.dart 174:15  StackZoneSpecification._run
-    package:stack_trace/src/stack_zone_specification.dart 119:52  registerCallback.<fn>
-    dart:async/zone.dart 706                                      _rootRun
-    dart:async/zone.dart 440                                      _ZoneDelegate.run
-    dart:async/zone.dart 650                                      _CustomizedZone.run
-    dart:async/zone.dart 561                                      _BaseZone.runGuarded
-    dart:async/zone.dart 586                                      _BaseZone.bindCallback.<fn>
-    package:stack_trace/src/stack_zone_specification.dart 174:15  StackZoneSpecification._run
-    package:stack_trace/src/stack_zone_specification.dart 119:52  registerCallback.<fn>
-    dart:async/zone.dart 710                                      _rootRun
-    dart:async/zone.dart 440                                      _ZoneDelegate.run
-    dart:async/zone.dart 650                                      _CustomizedZone.run
-    dart:async/zone.dart 561                                      _BaseZone.runGuarded
-    dart:async/zone.dart 586                                      _BaseZone.bindCallback.<fn>
-    dart:async-patch/timer_patch.dart 11                          _createTimer.<fn>
-    dart:io/timer_impl.dart 292                                   _handleTimeout
-    dart:isolate-patch/isolate_patch.dart 115                     _RawReceivePortImpl._handleMessage
+    Unhandled exception:
+    oh no!
+    example/example.dart 14:3                                     _runAsync
+    example/example.dart 10:52                                    _scheduleAsync.<fn>
+    package:stack_trace/src/stack_zone_specification.dart 126:26  StackZoneSpecification._registerUnaryCallback.<fn>.<fn>
+    package:stack_trace/src/stack_zone_specification.dart 208:15  StackZoneSpecification._run
+    package:stack_trace/src/stack_zone_specification.dart 126:14  StackZoneSpecification._registerUnaryCallback.<fn>
+    dart:async/zone.dart 1406:47                                  _rootRunUnary
+    dart:async/zone.dart 1307:19                                  _CustomZone.runUnary
     ===== asynchronous gap ===========================
-    dart:async/zone.dart 476                                      _ZoneDelegate.registerUnaryCallback
-    dart:async/zone.dart 666                                      _CustomizedZone.registerUnaryCallback
-    dart:async/future_impl.dart 164                               _Future._Future._then
-    dart:async/future_impl.dart 187                               _Future.then
-    test.dart 13:12                                               scheduleAsync
-    test.dart 7:18                                                main.<fn>
-    dart:async/zone.dart 710                                      _rootRun
-    dart:async/zone.dart 440                                      _ZoneDelegate.run
-    dart:async/zone.dart 650                                      _CustomizedZone.run
-    dart:async/zone.dart 944                                      runZoned
-    package:stack_trace/src/chain.dart 93:20                      Chain.capture
-    test.dart 6:16                                                main
-    dart:isolate-patch/isolate_patch.dart 216                     _startIsolate.isolateStartHandler
-    dart:isolate-patch/isolate_patch.dart 115                     _RawReceivePortImpl._handleMessage
+    dart:async/zone.dart 1328:19                                  _CustomZone.registerUnaryCallback
+    dart:async/future_impl.dart 315:23                            Future.then
+    example/example.dart 10:40                                    _scheduleAsync
+    package:stack_trace/src/chain.dart 97:24                      Chain.capture.<fn>
+    dart:async/zone.dart 1398:13                                  _rootRun
+    dart:async/zone.dart 1300:19                                  _CustomZone.run
+    dart:async/zone.dart 1803:10                                  _runZoned
+    dart:async/zone.dart 1746:10                                  runZoned
+    package:stack_trace/src/chain.dart 95:12                      Chain.capture
+    example/example.dart 6:9                                      main
+    dart:isolate-patch/isolate_patch.dart 297:19                  _delayEntrypointInvocation.<fn>
+    dart:isolate-patch/isolate_patch.dart 192:12                  _RawReceivePortImpl._handleMessage
 
 That's a lot of text! If you look closely, though, you can see that `main` is
 listed in the first trace in the chain.

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,9 +1,30 @@
 include: package:lints/recommended.yaml
 
 analyzer:
-  strong-mode:
-    implicit-casts: false
+  language:
+    strict-casts: true
+    strict-raw-types: true
 
 linter:
   rules:
+    - always_declare_return_types
     - avoid_private_typedef_functions
+    - avoid_unused_constructor_parameters
+    - cancel_subscriptions
+    - directives_ordering
+    - lines_longer_than_80_chars
+    - literal_only_boolean_expressions
+    - missing_whitespace_between_adjacent_strings
+    - no_adjacent_strings_in_list
+    - no_runtimeType_toString
+    - omit_local_variable_types
+    - package_api_docs
+    - prefer_relative_imports
+    - prefer_single_quotes
+    - test_types_in_equals
+    - throw_in_finally
+    - type_annotate_public_apis
+    - unawaited_futures
+    - unnecessary_await_in_return
+    - unnecessary_lambdas
+    - use_super_parameters

--- a/example/example.dart
+++ b/example/example.dart
@@ -1,0 +1,15 @@
+import 'dart:async';
+
+import 'package:stack_trace/stack_trace.dart';
+
+void main() {
+  Chain.capture(_scheduleAsync);
+}
+
+void _scheduleAsync() {
+  Future.delayed(Duration(seconds: 1)).then((_) => _runAsync());
+}
+
+void _runAsync() {
+  throw 'oh no!';
+}

--- a/lib/src/chain.dart
+++ b/lib/src/chain.dart
@@ -28,7 +28,7 @@ final _specKey = Object();
 ///
 /// Stack chains can be automatically tracked using [Chain.capture]. This sets
 /// up a new [Zone] in which the current stack chain is tracked and can be
-/// accessed using [new Chain.current]. Any errors that would be top-leveled in
+/// accessed using [Chain.current]. Any errors that would be top-leveled in
 /// the zone can be handled, along with their associated chains, with the
 /// `onError` callback. For example:
 ///
@@ -54,8 +54,8 @@ class Chain implements StackTrace {
   /// stack chain is tracked and automatically associated with (most) errors.
   ///
   /// If [when] is `false`, this does not track stack chains. Instead, it's
-  /// identical to [runZoned], except that it wraps any errors in [new
-  /// Chain.forTrace]—which will only wrap the trace unless there's a different
+  /// identical to [runZoned], except that it wraps any errors in
+  /// [Chain.forTrace]—which will only wrap the trace unless there's a different
   /// [Chain.capture] active. This makes it easy for the caller to only capture
   /// stack chains in debug mode or during development.
   ///
@@ -130,7 +130,7 @@ class Chain implements StackTrace {
   /// exceptions reported with [Completer.completeError] and
   /// [StreamController.addError] were tracked correctly.
   @Deprecated('Chain.track is not necessary in Dart 1.7+.')
-  static dynamic track(futureOrStream) => futureOrStream;
+  static dynamic track(Object? futureOrStream) => futureOrStream;
 
   /// Returns the current stack chain.
   ///
@@ -179,12 +179,11 @@ class Chain implements StackTrace {
       return Chain(chain
           .split(vmChainGap)
           .where((line) => line.isNotEmpty)
-          .map((trace) => Trace.parseVM(trace)));
+          .map(Trace.parseVM));
     }
     if (!chain.contains(chainGap)) return Chain([Trace.parse(chain)]);
 
-    return Chain(
-        chain.split(chainGap).map((trace) => Trace.parseFriendly(trace)));
+    return Chain(chain.split(chainGap).map(Trace.parseFriendly));
   }
 
   /// Returns a new [Chain] comprised of [traces].

--- a/lib/src/frame.dart
+++ b/lib/src/frame.dart
@@ -289,8 +289,8 @@ class Frame {
         var uri = match[1] == 'data:...'
             ? Uri.dataFromString('')
             : Uri.parse(match[1]!);
-        // If there's no scheme, this is a relative URI. We should interpret it as
-        // relative to the current working directory.
+        // If there's no scheme, this is a relative URI. We should interpret it
+        // as relative to the current working directory.
         if (uri.scheme == '') {
           uri = path.toUri(path.absolute(path.fromUri(uri)));
         }

--- a/lib/src/lazy_chain.dart
+++ b/lib/src/lazy_chain.dart
@@ -27,7 +27,7 @@ class LazyChain implements Chain {
   Chain foldFrames(bool Function(Frame) predicate, {bool terse = false}) =>
       LazyChain(() => _chain.foldFrames(predicate, terse: terse));
   @override
-  Trace toTrace() => LazyTrace(() => _chain.toTrace());
+  Trace toTrace() => LazyTrace(_chain.toTrace);
   @override
   String toString() => _chain.toString();
 }

--- a/lib/src/stack_zone_specification.dart
+++ b/lib/src/stack_zone_specification.dart
@@ -217,7 +217,7 @@ class StackZoneSpecification {
     }
   }
 
-  /// Like [new Trace.current], but if the current stack trace has VM chaining
+  /// Like [Trace.current], but if the current stack trace has VM chaining
   /// enabled, this only returns the innermost sub-trace.
   Trace _currentTrace([int? level]) {
     var stackTrace = StackTrace.current;

--- a/lib/src/trace.dart
+++ b/lib/src/trace.dart
@@ -156,10 +156,7 @@ class Trace implements StackTrace {
       return [];
     }
 
-    var frames = lines
-        .take(lines.length - 1)
-        .map((line) => Frame.parseVM(line))
-        .toList();
+    var frames = lines.take(lines.length - 1).map(Frame.parseVM).toList();
 
     // TODO(nweiz): Remove this when issue 23614 is fixed.
     if (!lines.last.endsWith('.da')) {
@@ -179,7 +176,7 @@ class Trace implements StackTrace {
                 // that looks like a V8 trace line, which will screw this up.
                 // Unfortunately, that's impossible to detect.
                 .skipWhile((line) => !line.startsWith(_v8TraceLine))
-                .map((line) => Frame.parseV8(line)),
+                .map(Frame.parseV8),
             original: trace);
 
   /// Parses a string representation of a JavaScriptCore stack trace.
@@ -188,7 +185,7 @@ class Trace implements StackTrace {
             trace
                 .split('\n')
                 .where((line) => line != '\tat ')
-                .map((line) => Frame.parseV8(line)),
+                .map(Frame.parseV8),
             original: trace);
 
   /// Parses a string representation of an Internet Explorer stack trace.
@@ -204,7 +201,7 @@ class Trace implements StackTrace {
                 .trim()
                 .split('\n')
                 .where((line) => line.isNotEmpty && line != '[native code]')
-                .map((line) => Frame.parseFirefox(line)),
+                .map(Frame.parseFirefox),
             original: trace);
 
   /// Parses a string representation of a Safari stack trace.
@@ -222,7 +219,7 @@ class Trace implements StackTrace {
                 .trim()
                 .split('\n')
                 .where((line) => line != '[native code]')
-                .map((line) => Frame.parseFirefox(line)),
+                .map(Frame.parseFirefox),
             original: trace);
 
   /// Parses this package's string representation of a stack trace.
@@ -238,7 +235,7 @@ class Trace implements StackTrace {
                     .split('\n')
                     // Filter out asynchronous gaps from [Chain]s.
                     .where((line) => !line.startsWith('====='))
-                    .map((line) => Frame.parseFriendly(line)),
+                    .map(Frame.parseFriendly),
             original: trace);
 
   /// Returns a new [Trace] comprised of [frames].

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,14 +1,14 @@
 name: stack_trace
-version: 1.11.0-dev
+version: 1.11.0
 description: A package for manipulating stack traces and printing them readably.
 repository: https://github.com/dart-lang/stack_trace
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.18.0 <3.0.0"
 
 dependencies:
   path: ^1.8.0
 
 dev_dependencies:
-  lints: ^1.0.0
+  lints: ^2.0.0
   test: ^1.16.0

--- a/test/chain/dart2js_test.dart
+++ b/test/chain/dart2js_test.dart
@@ -113,7 +113,7 @@ void main() {
 
     test('passed to a completer with no stack trace', () async {
       var chain = await captureFuture(() {
-        inMicrotask(() => completerErrorFuture());
+        inMicrotask(completerErrorFuture);
       });
 
       expect(chain.traces, hasLength(2));

--- a/test/chain/utils.dart
+++ b/test/chain/utils.dart
@@ -46,7 +46,7 @@ void inSyncFuture(void Function() callback) {
 /// Returns a Future that completes to an error using a completer.
 ///
 /// If [trace] is passed, it's used as the stack trace for the error.
-Future completerErrorFuture([StackTrace? trace]) {
+Future<void> completerErrorFuture([StackTrace? trace]) {
   var completer = Completer();
   completer.completeError('error', trace);
   return completer.future;
@@ -55,7 +55,7 @@ Future completerErrorFuture([StackTrace? trace]) {
 /// Returns a Stream that emits an error using a controller.
 ///
 /// If [trace] is passed, it's used as the stack trace for the error.
-Stream controllerErrorStream([StackTrace? trace]) {
+Stream<void> controllerErrorStream([StackTrace? trace]) {
   var controller = StreamController();
   controller.addError('error', trace);
   return controller.stream;

--- a/test/chain/vm_test.dart
+++ b/test/chain/vm_test.dart
@@ -8,10 +8,9 @@
 
 import 'dart:async';
 
-import 'package:test/test.dart';
-
-import 'package:stack_trace/stack_trace.dart';
 import 'package:stack_trace/src/utils.dart';
+import 'package:stack_trace/stack_trace.dart';
+import 'package:test/test.dart';
 
 import '../utils.dart';
 import 'utils.dart';
@@ -189,7 +188,7 @@ void main() {
 
     test('passed to a completer with no stack trace', () {
       return captureFuture(() {
-        inMicrotask(() => completerErrorFuture());
+        inMicrotask(completerErrorFuture);
       }).then((chain) {
         expect(chain.traces, hasLength(2));
 

--- a/test/frame_test.dart
+++ b/test/frame_test.dart
@@ -71,13 +71,11 @@ void main() {
 
   group('.parseV8', () {
     test('returns an UnparsedFrame for malformed frames', () {
-      expectIsUnparsed((text) => Frame.parseV8(text), '');
-      expectIsUnparsed((text) => Frame.parseV8(text), '#1');
-      expectIsUnparsed((text) => Frame.parseV8(text), '#1      Foo');
-      expectIsUnparsed((text) => Frame.parseV8(text),
-          '#1      (dart:async/future.dart:10:15)');
-      expectIsUnparsed(
-          (text) => Frame.parseV8(text), 'Foo (dart:async/future.dart:10:15)');
+      expectIsUnparsed(Frame.parseV8, '');
+      expectIsUnparsed(Frame.parseV8, '#1');
+      expectIsUnparsed(Frame.parseV8, '#1      Foo');
+      expectIsUnparsed(Frame.parseV8, '#1      (dart:async/future.dart:10:15)');
+      expectIsUnparsed(Frame.parseV8, 'Foo (dart:async/future.dart:10:15)');
     });
 
     test('parses a stack frame correctly', () {
@@ -219,19 +217,14 @@ void main() {
     });
 
     test('returns an UnparsedFrame for malformed frames', () {
-      expectIsUnparsed((text) => Frame.parseV8(text), '');
-      expectIsUnparsed((text) => Frame.parseV8(text), '    at');
-      expectIsUnparsed((text) => Frame.parseV8(text), '    at Foo');
-      expectIsUnparsed(
-          (text) => Frame.parseV8(text), '    at Foo (dart:async/future.dart)');
-      expectIsUnparsed((text) => Frame.parseV8(text),
-          '    at (dart:async/future.dart:10:15)');
-      expectIsUnparsed(
-          (text) => Frame.parseV8(text), 'Foo (dart:async/future.dart:10:15)');
-      expectIsUnparsed(
-          (text) => Frame.parseV8(text), '    at dart:async/future.dart');
-      expectIsUnparsed(
-          (text) => Frame.parseV8(text), 'dart:async/future.dart:10:15');
+      expectIsUnparsed(Frame.parseV8, '');
+      expectIsUnparsed(Frame.parseV8, '    at');
+      expectIsUnparsed(Frame.parseV8, '    at Foo');
+      expectIsUnparsed(Frame.parseV8, '    at Foo (dart:async/future.dart)');
+      expectIsUnparsed(Frame.parseV8, '    at (dart:async/future.dart:10:15)');
+      expectIsUnparsed(Frame.parseV8, 'Foo (dart:async/future.dart:10:15)');
+      expectIsUnparsed(Frame.parseV8, '    at dart:async/future.dart');
+      expectIsUnparsed(Frame.parseV8, 'dart:async/future.dart:10:15');
     });
   });
 
@@ -381,8 +374,9 @@ baz@https://pub.dev/buz.js:56355:55
     });
 
     test('parses a nested anonymous stack frame with parameters correctly', () {
-      var frame = Frame.parseFirefox('.foo(12, "@)()/<")/.fn<@'
-          'https://example.com/stuff.dart.js:560');
+      var frame = Frame.parseFirefox(
+        '.foo(12, "@)()/<")/.fn<@https://example.com/stuff.dart.js:560',
+      );
       expect(frame.uri, equals(Uri.parse('https://example.com/stuff.dart.js')));
       expect(frame.line, equals(560));
       expect(frame.column, isNull);
@@ -401,14 +395,11 @@ baz@https://pub.dev/buz.js:56355:55
     });
 
     test('returns an UnparsedFrame for malformed frames', () {
-      expectIsUnparsed((text) => Frame.parseFirefox(text), '');
-      expectIsUnparsed((text) => Frame.parseFirefox(text), '.foo');
-      expectIsUnparsed(
-          (text) => Frame.parseFirefox(text), '.foo@dart:async/future.dart');
-      expectIsUnparsed((text) => Frame.parseFirefox(text),
-          '.foo(@dart:async/future.dart:10');
-      expectIsUnparsed(
-          (text) => Frame.parseFirefox(text), '@dart:async/future.dart');
+      expectIsUnparsed(Frame.parseFirefox, '');
+      expectIsUnparsed(Frame.parseFirefox, '.foo');
+      expectIsUnparsed(Frame.parseFirefox, '.foo@dart:async/future.dart');
+      expectIsUnparsed(Frame.parseFirefox, '.foo(@dart:async/future.dart:10');
+      expectIsUnparsed(Frame.parseFirefox, '@dart:async/future.dart');
     });
 
     test('parses a simple stack frame correctly', () {
@@ -494,10 +485,9 @@ baz@https://pub.dev/buz.js:56355:55
     });
 
     test('returns an UnparsedFrame for malformed frames', () {
-      expectIsUnparsed((text) => Frame.parseFriendly(text), '');
-      expectIsUnparsed((text) => Frame.parseFriendly(text), 'foo/bar.dart');
-      expectIsUnparsed(
-          (text) => Frame.parseFriendly(text), 'foo/bar.dart 10:11');
+      expectIsUnparsed(Frame.parseFriendly, '');
+      expectIsUnparsed(Frame.parseFriendly, 'foo/bar.dart');
+      expectIsUnparsed(Frame.parseFriendly, 'foo/bar.dart 10:11');
     });
 
     test('parses a data url stack frame with no line or column correctly', () {

--- a/test/trace_test.dart
+++ b/test/trace_test.dart
@@ -12,7 +12,7 @@ Trace nestedGetCurrentTrace(int level) => getCurrentTrace(level);
 
 void main() {
   // This just shouldn't crash.
-  test('a native stack trace is parseable', () => Trace.current());
+  test('a native stack trace is parseable', Trace.current);
 
   group('.parse', () {
     test('.parse parses a V8 stack trace with eval statment correctly', () {
@@ -26,10 +26,10 @@ void main() {
 
     test('.parse parses a VM stack trace correctly', () {
       var trace = Trace.parse(
-          '#0      Foo._bar (file:///home/nweiz/code/stuff.dart:42:21)\n'
-          '#1      zip.<anonymous closure>.zap (dart:async/future.dart:0:2)\n'
-          '#2      zip.<anonymous closure>.zap (https://pub.dev/thing.'
-          'dart:1:100)');
+        '#0      Foo._bar (file:///home/nweiz/code/stuff.dart:42:21)\n'
+        '#1      zip.<anonymous closure>.zap (dart:async/future.dart:0:2)\n'
+        '#2      zip.<anonymous closure>.zap (https://pub.dev/thing.dart:1:100)',
+      );
 
       expect(trace.frames[0].uri,
           equals(Uri.parse('file:///home/nweiz/code/stuff.dart')));
@@ -250,12 +250,12 @@ void main() {
     });
 
     test('parses a package:stack_trace stack chain with end gap correctly', () {
-      var trace =
-          Trace.parse('https://dart.dev/foo/bar.dart 10:11  Foo.<fn>.bar\n'
-              'https://dart.dev/foo/baz.dart        Foo.<fn>.bar\n'
-              'https://dart.dev/foo/bang.dart 10:11  Foo.<fn>.bar\n'
-              'https://dart.dev/foo/quux.dart        Foo.<fn>.bar'
-              '===== asynchronous gap ===========================\n');
+      var trace = Trace.parse(
+        'https://dart.dev/foo/bar.dart 10:11  Foo.<fn>.bar\n'
+        'https://dart.dev/foo/baz.dart        Foo.<fn>.bar\n'
+        'https://dart.dev/foo/bang.dart 10:11  Foo.<fn>.bar\n'
+        'https://dart.dev/foo/quux.dart        Foo.<fn>.bar===== asynchronous gap ===========================\n',
+      );
 
       expect(trace.frames.length, 4);
       expect(trace.frames[0].uri,

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -5,11 +5,11 @@
 import 'package:test/test.dart';
 
 /// Returns a matcher that runs [matcher] against a [Frame]'s `member` field.
-Matcher frameMember(matcher) =>
+Matcher frameMember(Object? matcher) =>
     transform((frame) => frame.member, matcher, 'member');
 
 /// Returns a matcher that runs [matcher] against a [Frame]'s `library` field.
-Matcher frameLibrary(matcher) =>
+Matcher frameLibrary(Object? matcher) =>
     transform((frame) => frame.library, matcher, 'library');
 
 /// Returns a matcher that runs [transformation] on its input, then matches
@@ -17,8 +17,8 @@ Matcher frameLibrary(matcher) =>
 ///
 /// [description] should be a noun phrase that describes the relation of the
 /// output of [transformation] to its input.
-Matcher transform(
-        void Function(dynamic) transformation, matcher, String description) =>
+Matcher transform(void Function(dynamic) transformation, Object? matcher,
+        String description) =>
     _TransformMatcher(transformation, wrapMatcher(matcher), description);
 
 class _TransformMatcher extends Matcher {
@@ -29,7 +29,7 @@ class _TransformMatcher extends Matcher {
   _TransformMatcher(this._transformation, this._matcher, this._description);
 
   @override
-  bool matches(item, Map matchState) =>
+  bool matches(Object? item, Map<dynamic, dynamic> matchState) =>
       _matcher.matches(_transformation(item), matchState);
 
   @override


### PR DESCRIPTION
Require Dart 2.18
Bump lints dep
Enable and fix lints and language bits
Add an example
