### PR TITLE
Allow line/column numbers to be separated with colon. #68

### DIFF
--- a/lib/src/trace.dart
+++ b/lib/src/trace.dart
@@ -332,7 +332,12 @@ class Trace implements StackTrace {
     // Print out the stack trace nicely formatted.
     return frames.map((frame) {
       if (frame is UnparsedFrame) return '$frame\n';
-      return '${frame.location.padRight(longest)}  ${frame.member}\n';
+
+      // split the frame
+      final frameSplit = frame.toString().split(" ");
+      // extract the components of the frame and then concatenate with :
+      final frameLocation = frameSplit[0]+":"+frameSplit[1];
+      return '${frameLocation.padRight(longest)} ${frame.member}\n';
     }).join();
   }
 }


### PR DESCRIPTION
The issue mentioned was to change the Trace format from
`src\main.dart 27:15         main`
to
`src\main.dart:27:15         main`
so that by clicking `(CTRL+click)` and it would open the file at that exact point.

by editing the `toString()` method of Trace class i tried to resolve the issue mentioned.
 
The desired output format is achieved by splitting and extracting each frame into 4 components 
for example: 

`lib/_engine/engine/platform_dispatcher.dart 269:5 in invokeOnPointerDataPacket`
is extracted to a list of components
`[lib/_engine/engine/platform_dispatcher.dart, 269:5, in, invokeOnPointerDataPacket]`

and then concatenating them back with : so that the output format looks like
 `lib/_engine/engine/platform_dispatcher.dart:269:5                                 invokeOnPointerDataPacket`
having `:` in between URI and line number