### PR TITLE
Use awaiter-link pragma to guide VM's builtin awaiter stack unwinding

### DIFF
--- a/lib/src/stack_zone_specification.dart
+++ b/lib/src/stack_zone_specification.dart
@@ -117,7 +117,10 @@ class StackZoneSpecification {
   /// Tracks the current stack chain so it can be set to [_currentNode] when
   /// [f] is run.
   ZoneUnaryCallback<R, T> _registerUnaryCallback<R, T>(
-      Zone self, ZoneDelegate parent, Zone zone, R Function(T) f) {
+      Zone self,
+      ZoneDelegate parent,
+      Zone zone,
+      @pragma('vm:awaiter-link') R Function(T) f) {
     if (_disabled) return parent.registerUnaryCallback(zone, f);
     var node = _createNode(1);
     return parent.registerUnaryCallback(


### PR DESCRIPTION
This newly introduced pragma allows builtin awaiter stack unwinding to unwind awaiter chain through custom `Zone` callbacks, which fixes issues with native stack traces and debugger functionality (e.g. pause on uncaught exceptions will work better in tests which wrap code in `stack_trace`'s custom `Zone`). 