### PR TITLE
Prepare 1.11.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.11.1
+
+* Make use of `@pragma('vm:awaiter-link')` to make package work better with
+  Dart VM's builtin awaiter stack unwinding. No other changes.
+
 ## 1.11.0
 
 * Added the parameter `zoneValues` to `Chain.capture` to be able to use custom

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: stack_trace
-version: 1.11.0
+version: 1.11.1
 description: A package for manipulating stack traces and printing them readably.
 repository: https://github.com/dart-lang/stack_trace
 


### PR DESCRIPTION
The only change in this release is that we started to use `@pragma('vm:awaiter-link')` to improve interoperability between VM's builtin unwinder and the custom Zone the package creates. No API changes or changes on other platforms.
