### PR TITLE
Add support for parsing Wasm stack frames of Chrome (V8), Firefox, Safari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 1.11.2-wip
 
 * Require Dart 3.1 or greater
+* Added support for parsing Wasm frames of Chrome (V8), Firefox, Safari.
 
 ## 1.11.1
 

--- a/lib/src/frame.dart
+++ b/lib/src/frame.dart
@@ -44,9 +44,12 @@ final _v8JsUrlLocation = RegExp(r'^(.*?):(\d+)(?::(\d+))?$|native$');
 // - "uri":  `wasm://wasm/0006d966`.
 // - "index": `119`.
 // - "offset": (hex number) `bb13`.
+//
+// To avoid having multiple groups for the same part of the frame, this regex
+// matches unmatched parentheses after the member name.
 final _v8WasmFrame = RegExp(r'^\s*at (?:(?<member>.+) )?'
     r'(?:\(?(?:(?<uri>wasm:\S+):wasm-function\[(?<index>\d+)\]'
-    r'\:0x(?<offset>[0-9 a-f A-F]+))\)?)$');
+    r'\:0x(?<offset>[0-9a-fA-F]+))\)?)$');
 
 // eval as function (https://example.com/stuff.dart.js:560:28), efn:3:28
 // eval as function (https://example.com/stuff.dart.js:560:28)
@@ -98,8 +101,8 @@ final _firefoxSafariJSFrame = RegExp(r'^'
 // - "uri": `http://localhost:8080/test.wasm`.
 // - "index": `796`.
 // - "offset": (in hex) `143b4`.
-final _firefoxWasmFrame = RegExp(r'^(?<member>.*)@(?:(?<uri>.*):wasm-function'
-    r'\[(?<index>\d+)\]:0x(?<offset>[0-9 a-f A-F]+))$');
+final _firefoxWasmFrame = RegExp(r'^(?<member>.*?)@(?:(?<uri>.*?):wasm-function'
+    r'\[(?<index>\d+)\]:0x(?<offset>[0-9a-fA-F]+))$');
 
 // With names:
 //
@@ -114,7 +117,8 @@ final _firefoxWasmFrame = RegExp(r'^(?<member>.*)@(?:(?<uri>.*):wasm-function'
 // <?>.wasm-function[792]@[wasm code]
 //
 // Matches named group "member": `g` or `796`.
-final _safariWasmFrame = RegExp(r'^.*\[(?<member>.*)\]@\[wasm code\]$');
+final _safariWasmFrame =
+    RegExp(r'^.*?wasm-function\[(?<member>.*)\]@\[wasm code\]$');
 
 // foo/bar.dart 10:11 Foo._bar
 // foo/bar.dart 10:11 (anonymous function).dart.fn

--- a/lib/src/frame.dart
+++ b/lib/src/frame.dart
@@ -113,8 +113,8 @@ final _firefoxWasmFrame = RegExp(r'^(?<member>.*)@(?:(?<uri>.*):wasm-function'
 // <?>.wasm-function[795]@[wasm code]
 // <?>.wasm-function[792]@[wasm code]
 //
-// Group 1: Function name or index: `g` or `796`.
-final _safariWasmFrame = RegExp(r'^.*\[(.*)\]@\[wasm code\]$');
+// Matches named group "member": `g` or `796`.
+final _safariWasmFrame = RegExp(r'^.*\[(?<member>.*)\]@\[wasm code\]$');
 
 // foo/bar.dart 10:11 Foo._bar
 // foo/bar.dart 10:11 (anonymous function).dart.fn
@@ -351,7 +351,7 @@ class Frame {
 
         match = _safariWasmFrame.firstMatch(frame);
         if (match != null) {
-          final member = match[1]!;
+          final member = match.namedGroup('member')!;
           return Frame(Uri(path: 'wasm code'), null, null, member);
         }
 

--- a/lib/src/frame.dart
+++ b/lib/src/frame.dart
@@ -39,7 +39,7 @@ final _v8JsUrlLocation = RegExp(r'^(.*?):(\d+)(?::(\d+))?$|native$');
 //     at wasm://wasm/0005168a:wasm-function[796]:0x143b4
 //
 // Group 1: Function name, optional
-
+//
 // When group 1 is available:
 //   Group 2: URI
 //   Group 3: Function index

--- a/lib/src/frame.dart
+++ b/lib/src/frame.dart
@@ -94,10 +94,10 @@ final _firefoxSafariJSFrame = RegExp(r'^'
 //
 // Matches named groups:
 //
-// "member": Function name, may be empty: `g`.
-// "uri": `http://localhost:8080/test.wasm`.
-// "index": `796`.
-// "offset": (in hex) `143b4`.
+// - "member": Function name, may be empty: `g`.
+// - "uri": `http://localhost:8080/test.wasm`.
+// - "index": `796`.
+// - "offset": (in hex) `143b4`.
 final _firefoxWasmFrame = RegExp(r'^(?<member>.*)@(?:(?<uri>.*):wasm-function'
     r'\[(?<index>\d+)\]:0x(?<offset>[0-9 a-f A-F]+))$');
 

--- a/lib/src/frame.dart
+++ b/lib/src/frame.dart
@@ -97,10 +97,12 @@ final _firefoxSafariJSFrame = RegExp(r'^'
 // @http://localhost:8080/test.wasm:wasm-function[795]:0x143a8
 // @http://localhost:8080/test.wasm:wasm-function[792]:0x14390
 //
-// Group 1: Function name, may be empty.
-// Group 2: URI after the '@'.
-// Group 3: Function index.
-final _firefoxWasmFrame = RegExp(r'^(.*)@(.*\[(\d+)\]:.*)$');
+// Group 1: Function name, may be empty: `g`.
+// Group 2: URI: `http://localhost:8080/test.wasm`.
+// Group 3: Function index: `796`.
+// Group 4: Function offset in hex: `143b4`.
+final _firefoxWasmFrame =
+    RegExp(r'^(.*)@(?:(.*):wasm-function\[(\d+)\]:0x([0-9 a-f A-F]+))$');
 
 // With names:
 //
@@ -114,7 +116,7 @@ final _firefoxWasmFrame = RegExp(r'^(.*)@(.*\[(\d+)\]:.*)$');
 // <?>.wasm-function[795]@[wasm code]
 // <?>.wasm-function[792]@[wasm code]
 //
-// Group 1: Function name or index.
+// Group 1: Function name or index: `g` or `796`.
 final _safariWasmFrame = RegExp(r'^.*\[(.*)\]@\[wasm code\]$');
 
 // foo/bar.dart 10:11 Foo._bar
@@ -345,8 +347,9 @@ class Frame {
           final member = match[1]!;
           final uri = _uriOrPathToUri(match[2]!);
           final functionIndex = match[3]!;
-          return Frame(
-              uri, null, null, member.isNotEmpty ? member : functionIndex);
+          final functionOffset = int.parse(match[4]!, radix: 16);
+          return Frame(uri, 0, functionOffset,
+              member.isNotEmpty ? member : functionIndex);
         }
 
         match = _safariWasmFrame.firstMatch(frame);

--- a/lib/src/frame.dart
+++ b/lib/src/frame.dart
@@ -232,7 +232,7 @@ class Frame {
           final functionIndex = match.namedGroup('index')!;
           final functionOffset =
               int.parse(match.namedGroup('offset')!, radix: 16);
-          return Frame(uri, 1, functionOffset, member ?? functionIndex);
+          return Frame(uri, 1, functionOffset + 1, member ?? functionIndex);
         }
 
         match = _v8JsFrame.firstMatch(frame);
@@ -348,7 +348,7 @@ class Frame {
           final functionIndex = match.namedGroup('index')!;
           final functionOffset =
               int.parse(match.namedGroup('offset')!, radix: 16);
-          return Frame(uri, 1, functionOffset,
+          return Frame(uri, 1, functionOffset + 1,
               member.isNotEmpty ? member : functionIndex);
         }
 

--- a/lib/src/frame.dart
+++ b/lib/src/frame.dart
@@ -232,7 +232,7 @@ class Frame {
           final functionIndex = match.namedGroup('index')!;
           final functionOffset =
               int.parse(match.namedGroup('offset')!, radix: 16);
-          return Frame(uri, 0, functionOffset, member ?? functionIndex);
+          return Frame(uri, 1, functionOffset, member ?? functionIndex);
         }
 
         match = _v8JsFrame.firstMatch(frame);
@@ -348,7 +348,7 @@ class Frame {
           final functionIndex = match.namedGroup('index')!;
           final functionOffset =
               int.parse(match.namedGroup('offset')!, radix: 16);
-          return Frame(uri, 0, functionOffset,
+          return Frame(uri, 1, functionOffset,
               member.isNotEmpty ? member : functionIndex);
         }
 

--- a/lib/src/frame.dart
+++ b/lib/src/frame.dart
@@ -232,8 +232,8 @@ class Frame {
 
         match = _v8JsFrame.firstMatch(frame);
         if (match != null) {
-          // v8 location strings can be arbitrarily-nested, since it adds a layer
-          // of nesting for each eval performed on that line.
+          // v8 location strings can be arbitrarily-nested, since it adds a
+          // layer of nesting for each eval performed on that line.
           Frame parseJsLocation(String location, String member) {
             var evalMatch = _v8EvalLocation.firstMatch(location);
             while (evalMatch != null) {
@@ -258,8 +258,8 @@ class Frame {
           // V8 stack frames can be in two forms.
           if (match[2] != null) {
             // The first form looks like " at FUNCTION (LOCATION)". V8 proper
-            // lists anonymous functions within eval as "<anonymous>", while IE10
-            // lists them as "Anonymous function".
+            // lists anonymous functions within eval as "<anonymous>", while
+            // IE10 lists them as "Anonymous function".
             return parseJsLocation(
                 match[2]!,
                 match[1]!

--- a/lib/src/frame.dart
+++ b/lib/src/frame.dart
@@ -95,14 +95,26 @@ final _firefoxSafariJSFrame = RegExp(r'^'
 // @http://localhost:8080/test.wasm:wasm-function[795]:0x143a8
 // @http://localhost:8080/test.wasm:wasm-function[792]:0x14390
 //
+// JSShell in the command line uses a different format, which this regex also
+// parses.
+//
+// With names:
+//
+// main@/home/user/test.mjs line 29 > WebAssembly.compile:wasm-function[792]:0x14378
+//
+// Without names:
+//
+// @/home/user/test.mjs line 29 > WebAssembly.compile:wasm-function[792]:0x14378
+//
 // Matches named groups:
 //
 // - "member": Function name, may be empty: `g`.
 // - "uri": `http://localhost:8080/test.wasm`.
 // - "index": `796`.
 // - "offset": (in hex) `143b4`.
-final _firefoxWasmFrame = RegExp(r'^(?<member>.*?)@(?:(?<uri>.*?):wasm-function'
-    r'\[(?<index>\d+)\]:0x(?<offset>[0-9a-fA-F]+))$');
+final _firefoxWasmFrame =
+    RegExp(r'^(?<member>.*?)@(?:(?<uri>\S+).*?:wasm-function'
+        r'\[(?<index>\d+)\]:0x(?<offset>[0-9a-fA-F]+))$');
 
 // With names:
 //

--- a/lib/src/frame.dart
+++ b/lib/src/frame.dart
@@ -50,12 +50,6 @@ final _v8JsUrlLocation = RegExp(r'^(.*?):(\d+)(?::(\d+))?$|native$');
 final _v8WasmFrame = RegExp(r'^\s*at(?: (\S+))? '
     r'(?:\((wasm:\S+\[(\d+)\]\S+)\)|(wasm:\S+\[(\d+)\]\S+))$');
 
-// wasm://wasm/0006d966:wasm-function[796]:0x143b4
-//
-// Captures only one group with the all of the URL as Wasm stack traces don't
-// include line and column information, even with source maps.
-final _v8WasmUrlLocation = RegExp(r'^wasm:\/\/.*$');
-
 // eval as function (https://example.com/stuff.dart.js:560:28), efn:3:28
 // eval as function (https://example.com/stuff.dart.js:560:28)
 // eval as function (eval as otherFunction

--- a/lib/src/frame.dart
+++ b/lib/src/frame.dart
@@ -44,7 +44,7 @@ final _v8JsUrlLocation = RegExp(r'^(.*?):(\d+)(?::(\d+))?$|native$');
 // - "uri":  `wasm://wasm/0006d966`.
 // - "index": `119`.
 // - "offset": (hex number) `bb13`.
-final _v8WasmFrame = RegExp(r'^\s*at (?:(?<member>\S+) )?'
+final _v8WasmFrame = RegExp(r'^\s*at (?:(?<member>.+) )?'
     r'(?:\(?(?:(?<uri>wasm:\S+):wasm-function\[(?<index>\d+)\]'
     r'\:0x(?<offset>[0-9 a-f A-F]+))\)?)$');
 

--- a/lib/src/frame.dart
+++ b/lib/src/frame.dart
@@ -106,6 +106,9 @@ final _firefoxWasmFrame = RegExp(r'^(?<member>.*?)@(?:(?<uri>.*?):wasm-function'
 
 // With names:
 //
+// (Note: Lines below are literal text, e.g. <?> is not a placeholder, it's a
+// part of the stack frame.)
+//
 // <?>.wasm-function[g]@[wasm code]
 // <?>.wasm-function[f]@[wasm code]
 // <?>.wasm-function[main]@[wasm code]

--- a/lib/src/frame.dart
+++ b/lib/src/frame.dart
@@ -92,12 +92,14 @@ final _firefoxSafariJSFrame = RegExp(r'^'
 // @http://localhost:8080/test.wasm:wasm-function[795]:0x143a8
 // @http://localhost:8080/test.wasm:wasm-function[792]:0x14390
 //
-// Group 1: Function name, may be empty: `g`.
-// Group 2: URI: `http://localhost:8080/test.wasm`.
-// Group 3: Function index: `796`.
-// Group 4: Function offset in hex: `143b4`.
-final _firefoxWasmFrame =
-    RegExp(r'^(.*)@(?:(.*):wasm-function\[(\d+)\]:0x([0-9 a-f A-F]+))$');
+// Matches named groups:
+//
+// "member": Function name, may be empty: `g`.
+// "uri": `http://localhost:8080/test.wasm`.
+// "index": `796`.
+// "offset": (in hex) `143b4`.
+final _firefoxWasmFrame = RegExp(r'^(?<member>.*)@(?:(?<uri>.*):wasm-function'
+    r'\[(?<index>\d+)\]:0x(?<offset>[0-9 a-f A-F]+))$');
 
 // With names:
 //
@@ -338,10 +340,11 @@ class Frame {
 
         match = _firefoxWasmFrame.firstMatch(frame);
         if (match != null) {
-          final member = match[1]!;
-          final uri = _uriOrPathToUri(match[2]!);
-          final functionIndex = match[3]!;
-          final functionOffset = int.parse(match[4]!, radix: 16);
+          final member = match.namedGroup('member')!;
+          final uri = _uriOrPathToUri(match.namedGroup('uri')!);
+          final functionIndex = match.namedGroup('index')!;
+          final functionOffset =
+              int.parse(match.namedGroup('offset')!, radix: 16);
           return Frame(uri, 0, functionOffset,
               member.isNotEmpty ? member : functionIndex);
         }

--- a/test/frame_test.dart
+++ b/test/frame_test.dart
@@ -654,24 +654,18 @@ baz@https://pub.dev/buz.js:56355:55
   test('parses a Firefox Wasm frame with a name', () {
     var frame = Frame.parseFirefox(
         'g@http://localhost:8080/test.wasm:wasm-function[796]:0x143b4');
-    expect(
-        frame.uri,
-        Uri.parse(
-            'http://localhost:8080/test.wasm:wasm-function[796]:0x143b4'));
-    expect(frame.line, null);
-    expect(frame.column, null);
+    expect(frame.uri, Uri.parse('http://localhost:8080/test.wasm'));
+    expect(frame.line, 0);
+    expect(frame.column, 0x143b4);
     expect(frame.member, 'g');
   });
 
   test('parses a Firefox Wasm frame without a name', () {
     var frame = Frame.parseFirefox(
         '@http://localhost:8080/test.wasm:wasm-function[796]:0x143b4');
-    expect(
-        frame.uri,
-        Uri.parse(
-            'http://localhost:8080/test.wasm:wasm-function[796]:0x143b4'));
-    expect(frame.line, null);
-    expect(frame.column, null);
+    expect(frame.uri, Uri.parse('http://localhost:8080/test.wasm'));
+    expect(frame.line, 0);
+    expect(frame.column, 0x143b4);
     expect(frame.member, '796');
   });
 

--- a/test/frame_test.dart
+++ b/test/frame_test.dart
@@ -652,6 +652,30 @@ baz@https://pub.dev/buz.js:56355:55
     expect(frame.column, null);
     expect(frame.member, '119');
   });
+
+  test('parses a Firefox Wasm frame with a name', () {
+    var frame = Frame.parseFirefox(
+        'g@http://localhost:8080/test.wasm:wasm-function[796]:0x143b4');
+    expect(
+        frame.uri,
+        Uri.parse(
+            'http://localhost:8080/test.wasm:wasm-function[796]:0x143b4'));
+    expect(frame.line, null);
+    expect(frame.column, null);
+    expect(frame.member, 'g');
+  });
+
+  test('parses a Firefox Wasm frame without a name', () {
+    var frame = Frame.parseFirefox(
+        '@http://localhost:8080/test.wasm:wasm-function[796]:0x143b4');
+    expect(
+        frame.uri,
+        Uri.parse(
+            'http://localhost:8080/test.wasm:wasm-function[796]:0x143b4'));
+    expect(frame.line, null);
+    expect(frame.column, null);
+    expect(frame.member, '796');
+  });
 }
 
 void expectIsUnparsed(Frame Function(String) constructor, String text) {

--- a/test/frame_test.dart
+++ b/test/frame_test.dart
@@ -638,7 +638,7 @@ baz@https://pub.dev/buz.js:56355:55
         '(wasm://wasm/0006d966:wasm-function[119]:0xbb13)');
     expect(frame.uri, Uri.parse('wasm://wasm/0006d966'));
     expect(frame.line, 1);
-    expect(frame.column, 0xbb13);
+    expect(frame.column, 0xbb13 + 1);
     expect(frame.member, 'Error._throwWithCurrentStackTrace');
   });
 
@@ -647,7 +647,7 @@ baz@https://pub.dev/buz.js:56355:55
         '(wasm://wasm/0017fbea:wasm-function[863]:0x23cc8)');
     expect(frame.uri, Uri.parse('wasm://wasm/0017fbea'));
     expect(frame.line, 1);
-    expect(frame.column, 0x23cc8);
+    expect(frame.column, 0x23cc8 + 1);
     expect(frame.member, 'main tear-off trampoline');
   });
 
@@ -656,7 +656,7 @@ baz@https://pub.dev/buz.js:56355:55
         Frame.parseV8('    at wasm://wasm/0006d966:wasm-function[119]:0xbb13');
     expect(frame.uri, Uri.parse('wasm://wasm/0006d966'));
     expect(frame.line, 1);
-    expect(frame.column, 0xbb13);
+    expect(frame.column, 0xbb13 + 1);
     expect(frame.member, '119');
   });
 
@@ -665,7 +665,7 @@ baz@https://pub.dev/buz.js:56355:55
         'g@http://localhost:8080/test.wasm:wasm-function[796]:0x143b4');
     expect(frame.uri, Uri.parse('http://localhost:8080/test.wasm'));
     expect(frame.line, 1);
-    expect(frame.column, 0x143b4);
+    expect(frame.column, 0x143b4 + 1);
     expect(frame.member, 'g');
   });
 
@@ -674,7 +674,7 @@ baz@https://pub.dev/buz.js:56355:55
         'main tear-off trampoline@http://localhost:8080/test.wasm:wasm-function[794]:0x14387');
     expect(frame.uri, Uri.parse('http://localhost:8080/test.wasm'));
     expect(frame.line, 1);
-    expect(frame.column, 0x14387);
+    expect(frame.column, 0x14387 + 1);
     expect(frame.member, 'main tear-off trampoline');
   });
 
@@ -683,7 +683,7 @@ baz@https://pub.dev/buz.js:56355:55
         '@http://localhost:8080/test.wasm:wasm-function[796]:0x143b4');
     expect(frame.uri, Uri.parse('http://localhost:8080/test.wasm'));
     expect(frame.line, 1);
-    expect(frame.column, 0x143b4);
+    expect(frame.column, 0x143b4 + 1);
     expect(frame.member, '796');
   });
 

--- a/test/frame_test.dart
+++ b/test/frame_test.dart
@@ -636,20 +636,18 @@ baz@https://pub.dev/buz.js:56355:55
   test('parses a V8 Wasm frame with a name', () {
     var frame = Frame.parseV8('    at Error._throwWithCurrentStackTrace '
         '(wasm://wasm/0006d966:wasm-function[119]:0xbb13)');
-    expect(
-        frame.uri, Uri.parse('wasm://wasm/0006d966:wasm-function[119]:0xbb13'));
-    expect(frame.line, null);
-    expect(frame.column, null);
+    expect(frame.uri, Uri.parse('wasm://wasm/0006d966'));
+    expect(frame.line, 0);
+    expect(frame.column, 0xbb13);
     expect(frame.member, 'Error._throwWithCurrentStackTrace');
   });
 
   test('parses a V8 Wasm frame without a name', () {
     var frame =
         Frame.parseV8('    at wasm://wasm/0006d966:wasm-function[119]:0xbb13');
-    expect(
-        frame.uri, Uri.parse('wasm://wasm/0006d966:wasm-function[119]:0xbb13'));
-    expect(frame.line, null);
-    expect(frame.column, null);
+    expect(frame.uri, Uri.parse('wasm://wasm/0006d966'));
+    expect(frame.line, 0);
+    expect(frame.column, 0xbb13);
     expect(frame.member, '119');
   });
 

--- a/test/frame_test.dart
+++ b/test/frame_test.dart
@@ -637,7 +637,7 @@ baz@https://pub.dev/buz.js:56355:55
     var frame = Frame.parseV8('    at Error._throwWithCurrentStackTrace '
         '(wasm://wasm/0006d966:wasm-function[119]:0xbb13)');
     expect(frame.uri, Uri.parse('wasm://wasm/0006d966'));
-    expect(frame.line, 0);
+    expect(frame.line, 1);
     expect(frame.column, 0xbb13);
     expect(frame.member, 'Error._throwWithCurrentStackTrace');
   });
@@ -646,7 +646,7 @@ baz@https://pub.dev/buz.js:56355:55
     var frame = Frame.parseV8('   at main tear-off trampoline '
         '(wasm://wasm/0017fbea:wasm-function[863]:0x23cc8)');
     expect(frame.uri, Uri.parse('wasm://wasm/0017fbea'));
-    expect(frame.line, 0);
+    expect(frame.line, 1);
     expect(frame.column, 0x23cc8);
     expect(frame.member, 'main tear-off trampoline');
   });
@@ -655,7 +655,7 @@ baz@https://pub.dev/buz.js:56355:55
     var frame =
         Frame.parseV8('    at wasm://wasm/0006d966:wasm-function[119]:0xbb13');
     expect(frame.uri, Uri.parse('wasm://wasm/0006d966'));
-    expect(frame.line, 0);
+    expect(frame.line, 1);
     expect(frame.column, 0xbb13);
     expect(frame.member, '119');
   });
@@ -664,7 +664,7 @@ baz@https://pub.dev/buz.js:56355:55
     var frame = Frame.parseFirefox(
         'g@http://localhost:8080/test.wasm:wasm-function[796]:0x143b4');
     expect(frame.uri, Uri.parse('http://localhost:8080/test.wasm'));
-    expect(frame.line, 0);
+    expect(frame.line, 1);
     expect(frame.column, 0x143b4);
     expect(frame.member, 'g');
   });
@@ -673,7 +673,7 @@ baz@https://pub.dev/buz.js:56355:55
     var frame = Frame.parseFirefox(
         'main tear-off trampoline@http://localhost:8080/test.wasm:wasm-function[794]:0x14387');
     expect(frame.uri, Uri.parse('http://localhost:8080/test.wasm'));
-    expect(frame.line, 0);
+    expect(frame.line, 1);
     expect(frame.column, 0x14387);
     expect(frame.member, 'main tear-off trampoline');
   });
@@ -682,7 +682,7 @@ baz@https://pub.dev/buz.js:56355:55
     var frame = Frame.parseFirefox(
         '@http://localhost:8080/test.wasm:wasm-function[796]:0x143b4');
     expect(frame.uri, Uri.parse('http://localhost:8080/test.wasm'));
-    expect(frame.line, 0);
+    expect(frame.line, 1);
     expect(frame.column, 0x143b4);
     expect(frame.member, '796');
   });

--- a/test/frame_test.dart
+++ b/test/frame_test.dart
@@ -676,6 +676,22 @@ baz@https://pub.dev/buz.js:56355:55
     expect(frame.column, null);
     expect(frame.member, '796');
   });
+
+  test('parses a Safari Wasm frame with a name', () {
+    var frame = Frame.parseSafari('<?>.wasm-function[g]@[wasm code]');
+    expect(frame.uri, Uri.parse('wasm code'));
+    expect(frame.line, null);
+    expect(frame.column, null);
+    expect(frame.member, 'g');
+  });
+
+  test('parses a Safari Wasm frame without a name', () {
+    var frame = Frame.parseSafari('<?>.wasm-function[796]@[wasm code]');
+    expect(frame.uri, Uri.parse('wasm code'));
+    expect(frame.line, null);
+    expect(frame.column, null);
+    expect(frame.member, '796');
+  });
 }
 
 void expectIsUnparsed(Frame Function(String) constructor, String text) {

--- a/test/frame_test.dart
+++ b/test/frame_test.dart
@@ -632,6 +632,26 @@ baz@https://pub.dev/buz.js:56355:55
           equals('$relative 5:10 in Foo'));
     });
   });
+
+  test('parses a V8 Wasm frame with a name', () {
+    var frame = Frame.parseV8('    at Error._throwWithCurrentStackTrace '
+        '(wasm://wasm/0006d966:wasm-function[119]:0xbb13)');
+    expect(
+        frame.uri, Uri.parse('wasm://wasm/0006d966:wasm-function[119]:0xbb13'));
+    expect(frame.line, null);
+    expect(frame.column, null);
+    expect(frame.member, 'Error._throwWithCurrentStackTrace');
+  });
+
+  test('parses a V8 Wasm frame without a name', () {
+    var frame =
+        Frame.parseV8('    at wasm://wasm/0006d966:wasm-function[119]:0xbb13');
+    expect(
+        frame.uri, Uri.parse('wasm://wasm/0006d966:wasm-function[119]:0xbb13'));
+    expect(frame.line, null);
+    expect(frame.column, null);
+    expect(frame.member, '119');
+  });
 }
 
 void expectIsUnparsed(Frame Function(String) constructor, String text) {

--- a/test/frame_test.dart
+++ b/test/frame_test.dart
@@ -642,6 +642,15 @@ baz@https://pub.dev/buz.js:56355:55
     expect(frame.member, 'Error._throwWithCurrentStackTrace');
   });
 
+  test('parses a V8 Wasm frame with a name with spaces', () {
+    var frame = Frame.parseV8('   at main tear-off trampoline '
+        '(wasm://wasm/0017fbea:wasm-function[863]:0x23cc8)');
+    expect(frame.uri, Uri.parse('wasm://wasm/0017fbea'));
+    expect(frame.line, 0);
+    expect(frame.column, 0x23cc8);
+    expect(frame.member, 'main tear-off trampoline');
+  });
+
   test('parses a V8 Wasm frame without a name', () {
     var frame =
         Frame.parseV8('    at wasm://wasm/0006d966:wasm-function[119]:0xbb13');
@@ -660,6 +669,15 @@ baz@https://pub.dev/buz.js:56355:55
     expect(frame.member, 'g');
   });
 
+  test('parses a Firefox Wasm frame with a name with spaces', () {
+    var frame = Frame.parseFirefox(
+        'main tear-off trampoline@http://localhost:8080/test.wasm:wasm-function[794]:0x14387');
+    expect(frame.uri, Uri.parse('http://localhost:8080/test.wasm'));
+    expect(frame.line, 0);
+    expect(frame.column, 0x14387);
+    expect(frame.member, 'main tear-off trampoline');
+  });
+
   test('parses a Firefox Wasm frame without a name', () {
     var frame = Frame.parseFirefox(
         '@http://localhost:8080/test.wasm:wasm-function[796]:0x143b4');
@@ -675,6 +693,15 @@ baz@https://pub.dev/buz.js:56355:55
     expect(frame.line, null);
     expect(frame.column, null);
     expect(frame.member, 'g');
+  });
+
+  test('parses a Safari Wasm frame with a name', () {
+    var frame = Frame.parseSafari(
+        '<?>.wasm-function[main tear-off trampoline]@[wasm code]');
+    expect(frame.uri, Uri.parse('wasm code'));
+    expect(frame.line, null);
+    expect(frame.column, null);
+    expect(frame.member, 'main tear-off trampoline');
   });
 
   test('parses a Safari Wasm frame without a name', () {

--- a/test/trace_test.dart
+++ b/test/trace_test.dart
@@ -310,25 +310,14 @@ void main() {
 
       expect(trace.frames.length, 8);
 
+      for (final frame in trace.frames) {
+        expect(frame is UnparsedFrame, false);
+      }
+
       expect(trace.frames[0].uri, Uri.parse('wasm://wasm/0006d892'));
       expect(trace.frames[0].line, 1);
       expect(trace.frames[0].column, 0xbaf8 + 1);
       expect(trace.frames[0].member, 'Error._throwWithCurrentStackTrace');
-
-      expect(trace.frames[1].uri, Uri.parse('wasm://wasm/0006d892'));
-      expect(trace.frames[1].line, 1);
-      expect(trace.frames[1].column, 0x14378 + 1);
-      expect(trace.frames[1].member, 'main');
-
-      expect(trace.frames[2].uri, Uri.parse('wasm://wasm/0006d892'));
-      expect(trace.frames[2].line, 1);
-      expect(trace.frames[2].column, 0x14387 + 1);
-      expect(trace.frames[2].member, 'main tear-off trampoline');
-
-      expect(trace.frames[3].uri, Uri.parse('wasm://wasm/0006d892'));
-      expect(trace.frames[3].line, 1);
-      expect(trace.frames[3].column, 0xa56c + 1);
-      expect(trace.frames[3].member, '_invokeMain');
 
       expect(trace.frames[4].uri, Uri.parse('file:///home/user/test.mjs'));
       expect(trace.frames[4].line, 361);
@@ -339,16 +328,6 @@ void main() {
       expect(trace.frames[5].line, 416);
       expect(trace.frames[5].column, 21);
       expect(trace.frames[5].member, 'main');
-
-      expect(trace.frames[6].uri, Uri.parse('file:///home/user/run_wasm.js'));
-      expect(trace.frames[6].line, 353);
-      expect(trace.frames[6].column, 38);
-      expect(trace.frames[6].member, 'async action');
-
-      expect(trace.frames[7].uri, Uri.parse('file:///home/user/run_wasm.js'));
-      expect(trace.frames[7].line, 329);
-      expect(trace.frames[7].column, 9);
-      expect(trace.frames[7].member, 'async eventLoop');
     });
 
     test('parses Firefox stack frace with Wasm frames correctly', () {
@@ -361,25 +340,14 @@ void main() {
 
       expect(trace.frames.length, 5);
 
+      for (final frame in trace.frames) {
+        expect(frame is UnparsedFrame, false);
+      }
+
       expect(trace.frames[0].uri, Uri.parse('http://localhost:8080/test.wasm'));
       expect(trace.frames[0].line, 1);
       expect(trace.frames[0].column, 0xbaf8 + 1);
       expect(trace.frames[0].member, 'Error._throwWithCurrentStackTrace');
-
-      expect(trace.frames[1].uri, Uri.parse('http://localhost:8080/test.wasm'));
-      expect(trace.frames[1].line, 1);
-      expect(trace.frames[1].column, 0x14378 + 1);
-      expect(trace.frames[1].member, 'main');
-
-      expect(trace.frames[2].uri, Uri.parse('http://localhost:8080/test.wasm'));
-      expect(trace.frames[2].line, 1);
-      expect(trace.frames[2].column, 0x14387 + 1);
-      expect(trace.frames[2].member, 'main tear-off trampoline');
-
-      expect(trace.frames[3].uri, Uri.parse('http://localhost:8080/test.wasm'));
-      expect(trace.frames[3].line, 1);
-      expect(trace.frames[3].column, 0xa56c + 1);
-      expect(trace.frames[3].member, '_invokeMain');
 
       expect(trace.frames[4].uri, Uri.parse('http://localhost:8080/test.mjs'));
       expect(trace.frames[4].line, 48);
@@ -401,6 +369,10 @@ void main() {
           '@/home/user/run_wasm.js:419:15');
 
       expect(trace.frames.length, 10);
+
+      for (final frame in trace.frames) {
+        expect(frame is UnparsedFrame, false);
+      }
 
       expect(trace.frames[0].uri, Uri.parse('file:///home/user/test.mjs'));
       expect(trace.frames[0].line, 1);

--- a/test/trace_test.dart
+++ b/test/trace_test.dart
@@ -296,6 +296,138 @@ void main() {
       expect(trace.frames[0].uri, equals(Uri.parse('file:///pull.dart')));
       expect(trace.frames[1].uri, equals(Uri.parse('dart:the/future.dart')));
     });
+
+    test('parses a V8 stack frace with Wasm frames correctly', () {
+      var trace = Trace.parse(
+          '\tat Error._throwWithCurrentStackTrace (wasm://wasm/0006d892:wasm-function[119]:0xbaf8)\n'
+          '\tat main (wasm://wasm/0006d892:wasm-function[792]:0x14378)\n'
+          '\tat main tear-off trampoline (wasm://wasm/0006d892:wasm-function[794]:0x14387)\n'
+          '\tat _invokeMain (wasm://wasm/0006d892:wasm-function[70]:0xa56c)\n'
+          '\tat InstantiatedApp.invokeMain (/home/user/test.mjs:361:37)\n'
+          '\tat main (/home/user/run_wasm.js:416:21)\n'
+          '\tat async action (/home/user/run_wasm.js:353:38)\n'
+          '\tat async eventLoop (/home/user/run_wasm.js:329:9)');
+
+      expect(trace.frames.length, 8);
+
+      expect(trace.frames[0].uri, Uri.parse('wasm://wasm/0006d892'));
+      expect(trace.frames[0].line, 1);
+      expect(trace.frames[0].column, 0xbaf8 + 1);
+      expect(trace.frames[0].member, 'Error._throwWithCurrentStackTrace');
+
+      expect(trace.frames[1].uri, Uri.parse('wasm://wasm/0006d892'));
+      expect(trace.frames[1].line, 1);
+      expect(trace.frames[1].column, 0x14378 + 1);
+      expect(trace.frames[1].member, 'main');
+
+      expect(trace.frames[2].uri, Uri.parse('wasm://wasm/0006d892'));
+      expect(trace.frames[2].line, 1);
+      expect(trace.frames[2].column, 0x14387 + 1);
+      expect(trace.frames[2].member, 'main tear-off trampoline');
+
+      expect(trace.frames[3].uri, Uri.parse('wasm://wasm/0006d892'));
+      expect(trace.frames[3].line, 1);
+      expect(trace.frames[3].column, 0xa56c + 1);
+      expect(trace.frames[3].member, '_invokeMain');
+
+      expect(trace.frames[4].uri, Uri.parse('file:///home/user/test.mjs'));
+      expect(trace.frames[4].line, 361);
+      expect(trace.frames[4].column, 37);
+      expect(trace.frames[4].member, 'InstantiatedApp.invokeMain');
+
+      expect(trace.frames[5].uri, Uri.parse('file:///home/user/run_wasm.js'));
+      expect(trace.frames[5].line, 416);
+      expect(trace.frames[5].column, 21);
+      expect(trace.frames[5].member, 'main');
+
+      expect(trace.frames[6].uri, Uri.parse('file:///home/user/run_wasm.js'));
+      expect(trace.frames[6].line, 353);
+      expect(trace.frames[6].column, 38);
+      expect(trace.frames[6].member, 'async action');
+
+      expect(trace.frames[7].uri, Uri.parse('file:///home/user/run_wasm.js'));
+      expect(trace.frames[7].line, 329);
+      expect(trace.frames[7].column, 9);
+      expect(trace.frames[7].member, 'async eventLoop');
+    });
+
+    test('parses Firefox stack frace with Wasm frames correctly', () {
+      var trace = Trace.parse(
+          'Error._throwWithCurrentStackTrace@http://localhost:8080/test.wasm:wasm-function[119]:0xbaf8\n'
+          'main@http://localhost:8080/test.wasm:wasm-function[792]:0x14378\n'
+          'main tear-off trampoline@http://localhost:8080/test.wasm:wasm-function[794]:0x14387\n'
+          '_invokeMain@http://localhost:8080/test.wasm:wasm-function[70]:0xa56c\n'
+          'invoke@http://localhost:8080/test.mjs:48:26');
+
+      expect(trace.frames.length, 5);
+
+      expect(trace.frames[0].uri, Uri.parse('http://localhost:8080/test.wasm'));
+      expect(trace.frames[0].line, 1);
+      expect(trace.frames[0].column, 0xbaf8 + 1);
+      expect(trace.frames[0].member, 'Error._throwWithCurrentStackTrace');
+
+      expect(trace.frames[1].uri, Uri.parse('http://localhost:8080/test.wasm'));
+      expect(trace.frames[1].line, 1);
+      expect(trace.frames[1].column, 0x14378 + 1);
+      expect(trace.frames[1].member, 'main');
+
+      expect(trace.frames[2].uri, Uri.parse('http://localhost:8080/test.wasm'));
+      expect(trace.frames[2].line, 1);
+      expect(trace.frames[2].column, 0x14387 + 1);
+      expect(trace.frames[2].member, 'main tear-off trampoline');
+
+      expect(trace.frames[3].uri, Uri.parse('http://localhost:8080/test.wasm'));
+      expect(trace.frames[3].line, 1);
+      expect(trace.frames[3].column, 0xa56c + 1);
+      expect(trace.frames[3].member, '_invokeMain');
+
+      expect(trace.frames[4].uri, Uri.parse('http://localhost:8080/test.mjs'));
+      expect(trace.frames[4].line, 48);
+      expect(trace.frames[4].column, 26);
+      expect(trace.frames[4].member, 'invoke');
+    });
+
+    test('parses Safari stack frace with Wasm frames correctly', () {
+      var trace = Trace.parse(
+          '<?>.wasm-function[Error._throwWithCurrentStackTrace]@[wasm code]\n'
+          '<?>.wasm-function[main]@[wasm code]\n'
+          '<?>.wasm-function[main tear-off trampoline]@[wasm code]\n'
+          '<?>.wasm-function[_invokeMain]@[wasm code]\n'
+          'invokeMain@/home/user/test.mjs:361:48\n'
+          '@/home/user/run_wasm.js:416:31');
+
+      expect(trace.frames.length, 6);
+
+      expect(trace.frames[0].uri, Uri.parse('wasm code'));
+      expect(trace.frames[0].line, null);
+      expect(trace.frames[0].column, null);
+      expect(trace.frames[0].member, 'Error._throwWithCurrentStackTrace');
+
+      expect(trace.frames[1].uri, Uri.parse('wasm code'));
+      expect(trace.frames[1].line, null);
+      expect(trace.frames[1].column, null);
+      expect(trace.frames[1].member, 'main');
+
+      expect(trace.frames[2].uri, Uri.parse('wasm code'));
+      expect(trace.frames[2].line, null);
+      expect(trace.frames[2].column, null);
+      expect(trace.frames[2].member, 'main tear-off trampoline');
+
+      expect(trace.frames[3].uri, Uri.parse('wasm code'));
+      expect(trace.frames[3].line, null);
+      expect(trace.frames[3].column, null);
+      expect(trace.frames[3].member, '_invokeMain');
+
+      expect(trace.frames[4].uri, Uri.parse('file:///home/user/test.mjs'));
+      expect(trace.frames[4].line, 361);
+      expect(trace.frames[4].column, 48);
+      expect(trace.frames[4].member, 'invokeMain');
+
+      expect(trace.frames[5].uri, Uri.parse('file:///home/user/run_wasm.js'));
+      expect(trace.frames[5].line, 416);
+      expect(trace.frames[5].column, 31);
+      expect(trace.frames[5].member, '<fn>');
+    });
   });
 
   test('.toString() nicely formats the stack trace', () {

--- a/test/trace_test.dart
+++ b/test/trace_test.dart
@@ -387,6 +387,37 @@ void main() {
       expect(trace.frames[4].member, 'invoke');
     });
 
+    test('parses JSShell stack frace with Wasm frames correctly', () {
+      var trace = Trace.parse(
+          'Error._throwWithCurrentStackTrace@/home/user/test.mjs line 29 > WebAssembly.compile:wasm-function[119]:0xbaf8\n'
+          'main@/home/user/test.mjs line 29 > WebAssembly.compile:wasm-function[792]:0x14378\n'
+          'main tear-off trampoline@/home/user/test.mjs line 29 > WebAssembly.compile:wasm-function[794]:0x14387\n'
+          '_invokeMain@/home/user/test.mjs line 29 > WebAssembly.compile:wasm-function[70]:0xa56c\n'
+          'invokeMain@/home/user/test.mjs:361:37\n'
+          'main@/home/user/run_wasm.js:416:21\n'
+          'async*action@/home/user/run_wasm.js:353:44\n'
+          'eventLoop@/home/user/run_wasm.js:329:15\n'
+          'self.dartMainRunner@/home/user/run_wasm.js:354:14\n'
+          '@/home/user/run_wasm.js:419:15');
+
+      expect(trace.frames.length, 10);
+
+      expect(trace.frames[0].uri, Uri.parse('file:///home/user/test.mjs'));
+      expect(trace.frames[0].line, 1);
+      expect(trace.frames[0].column, 0xbaf8 + 1);
+      expect(trace.frames[0].member, 'Error._throwWithCurrentStackTrace');
+
+      expect(trace.frames[4].uri, Uri.parse('file:///home/user/test.mjs'));
+      expect(trace.frames[4].line, 361);
+      expect(trace.frames[4].column, 37);
+      expect(trace.frames[4].member, 'invokeMain');
+
+      expect(trace.frames[9].uri, Uri.parse('file:///home/user/run_wasm.js'));
+      expect(trace.frames[9].line, 419);
+      expect(trace.frames[9].column, 15);
+      expect(trace.frames[9].member, '<fn>');
+    });
+
     test('parses Safari stack frace with Wasm frames correctly', () {
       var trace = Trace.parse(
           '<?>.wasm-function[Error._throwWithCurrentStackTrace]@[wasm code]\n'

--- a/test/trace_test.dart
+++ b/test/trace_test.dart
@@ -401,25 +401,14 @@ void main() {
 
       expect(trace.frames.length, 6);
 
+      for (final frame in trace.frames) {
+        expect(frame is UnparsedFrame, false);
+      }
+
       expect(trace.frames[0].uri, Uri.parse('wasm code'));
       expect(trace.frames[0].line, null);
       expect(trace.frames[0].column, null);
       expect(trace.frames[0].member, 'Error._throwWithCurrentStackTrace');
-
-      expect(trace.frames[1].uri, Uri.parse('wasm code'));
-      expect(trace.frames[1].line, null);
-      expect(trace.frames[1].column, null);
-      expect(trace.frames[1].member, 'main');
-
-      expect(trace.frames[2].uri, Uri.parse('wasm code'));
-      expect(trace.frames[2].line, null);
-      expect(trace.frames[2].column, null);
-      expect(trace.frames[2].member, 'main tear-off trampoline');
-
-      expect(trace.frames[3].uri, Uri.parse('wasm code'));
-      expect(trace.frames[3].line, null);
-      expect(trace.frames[3].column, null);
-      expect(trace.frames[3].member, '_invokeMain');
 
       expect(trace.frames[4].uri, Uri.parse('file:///home/user/test.mjs'));
       expect(trace.frames[4].line, 361);


### PR DESCRIPTION
Instead of updating existing regexes to handle new formats, this adds new
regexes for Wasm frames.

Parser functions are updated to try to parse the frame with Wasm regexes.

Column numbers can be used by the `source_map_stack_trace` package to map Wasm
frames to source locations.

Tests added for parsing all combinations of:

- Frames with and without function names
- In Chrome, Firefox, Safari formats